### PR TITLE
Fix bug iterating over 1 step

### DIFF
--- a/tests/test_fairworkflow.py
+++ b/tests/test_fairworkflow.py
@@ -144,9 +144,20 @@ class TestFairWorkflow:
 
     def test_iterator_one_step(self):
         workflow = FairWorkflow()
-        workflow.add(FairStep('test'))
+        workflow.add(self.step1)
         workflow_steps = list(workflow)
         assert len(workflow_steps) == 1
+
+    def test_iterator_sorting_failed(self):
+        workflow = FairWorkflow()
+        workflow.add(self.step1)
+
+        # Add a step that follows a step not in the workflow. There are now 2
+        # steps in the workflow that are not connected by a precedes
+        # predicate. This should lead to a RuntimeError.
+        workflow.add(self.step2, follows=FairStep('not in workflow'))
+        with pytest.raises(RuntimeError):
+            list(workflow)
 
     def test_validate_inputs_outputs(self):
         # Step 1 precedes step 2, so valid if input of 2 is output of 1

--- a/tests/test_fairworkflow.py
+++ b/tests/test_fairworkflow.py
@@ -142,6 +142,12 @@ class TestFairWorkflow:
         for i, step in enumerate(workflow_steps):
             assert step == right_order_steps[i]
 
+    def test_iterator_one_step(self):
+        workflow = FairWorkflow()
+        workflow.add(FairStep('test'))
+        workflow_steps = list(workflow)
+        assert len(workflow_steps) == 1
+
     def test_validate_inputs_outputs(self):
         # Step 1 precedes step 2, so valid if input of 2 is output of 1
         self.step1.outputs = ['var1']


### PR DESCRIPTION
Iterating over workflows with 1 step actually returned an empty iterator. This fixes this bug.
Also implements raising a RunTimeError in other cases where we cannot sort on the 'precedes' predicate.