### PR TITLE
Move  from_nanopub method to RdfWrapper class

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,15 @@
+import pytest
+import requests
+
+NANOPUB_SERVER = 'http://purl.org/np/'
+
+
+def nanopub_server_available():
+    response = requests.get(NANOPUB_SERVER)
+    return response.status_code == 200
+
+
+skip_if_nanopub_server_unavailable = (
+    pytest.mark.skipif(not nanopub_server_available(),
+                       reason='Nanopub server is unavailable'))
+

--- a/conftest.py
+++ b/conftest.py
@@ -3,13 +3,7 @@ import requests
 
 NANOPUB_SERVER = 'http://purl.org/np/'
 
-
-def nanopub_server_available():
-    response = requests.get(NANOPUB_SERVER)
-    return response.status_code == 200
-
-
 skip_if_nanopub_server_unavailable = (
-    pytest.mark.skipif(not nanopub_server_available(),
+    pytest.mark.skipif(requests.get(NANOPUB_SERVER).status_code != 200,
                        reason='Nanopub server is unavailable'))
 

--- a/fairworkflows/fairstep.py
+++ b/fairworkflows/fairstep.py
@@ -32,45 +32,21 @@ class FairStep(RdfWrapper):
         super().__init__(uri=uri, ref_name='step')
 
     @classmethod
-    def from_rdf(cls, rdf, uri=None):
-        """Construct Fair Step from existing RDF."""
+    def from_rdf(cls, rdf, uri=None, fetch_references: bool = False):
+        """Construct Fair Step from existing RDF.
+
+        Args:
+            rdf: The RDF graph
+            uri: Uri of the object
+            fetch_references: Boolean toggling whether to fetch objects from nanopub that are
+                referred by this object. For a FairStep there are currently no references supported.
+        """
         self = cls(uri)
         self._rdf = rdf
         if rdflib.URIRef(self._uri) not in rdf.subjects():
             warnings.warn(f"Warning: Provided URI '{self._uri}' does not "
                           f"match any subject in provided rdf graph.")
         self.anonymise_rdf()
-        return self
-
-    @classmethod
-    def from_nanopub(cls, uri):
-        """Construct FairStep object from an existing nanopublication.
-
-        Fetch the nanopublication corresponding to the specified URI, and attempt to extract the
-        rdf describing a fairstep from its assertion graph. If the URI passed to this function is
-        the uri of the nanopublication (and not the step itself) then an attempt will be made to
-        identify what the URI of the step actually is, by checking if the nanopub npx:introduces a
-        particular concept.
-        """
-        # Work out the nanopub URI by defragging the step URI
-        nanopub_uri, frag = urldefrag(uri)
-
-        # Fetch the nanopub
-        client = NanopubClient()
-        nanopub = client.fetch(nanopub_uri)
-
-        if len(frag) > 0:
-            # If we found a fragment we can use the passed URI
-            uri = uri
-        elif nanopub.introduces_concept:
-            # Otherwise we try to extract it from 'introduced concept'
-            uri = str(nanopub.introduces_concept)
-        else:
-            raise ValueError('This nanopub does not introduce any concepts. Please provide URI to '
-                             'the FAIR object itself (not just the nanopub).')
-        self = cls.from_rdf(rdf=nanopub.assertion, uri=uri)
-        # Record that this RDF originates from a published source
-        self._is_published = True
         return self
 
     @classmethod

--- a/fairworkflows/fairstep.py
+++ b/fairworkflows/fairstep.py
@@ -30,7 +30,7 @@ class FairStep(RdfWrapper):
         super().__init__(uri=uri, ref_name='step')
 
     @classmethod
-    def from_rdf(cls, rdf, uri=None, fetch_references: bool = False):
+    def from_rdf(cls, rdf, uri=None, fetch_references: bool = False, force: bool = False):
         """Construct Fair Step from existing RDF.
 
         Args:
@@ -38,12 +38,12 @@ class FairStep(RdfWrapper):
             uri: Uri of the object
             fetch_references: Boolean toggling whether to fetch objects from nanopub that are
                 referred by this object. For a FairStep there are currently no references supported.
+            force: Toggle forcing creation of object even if url is not in any of the subjects of
+                the passed RDF
         """
+        cls._uri_is_subject_in_rdf(uri, rdf, raise_error=(not force))
         self = cls(uri)
         self._rdf = rdf
-        if rdflib.URIRef(self._uri) not in rdf.subjects():
-            warnings.warn(f"Warning: Provided URI '{self._uri}' does not "
-                          f"match any subject in provided rdf graph.")
         self.anonymise_rdf()
         return self
 

--- a/fairworkflows/fairstep.py
+++ b/fairworkflows/fairstep.py
@@ -41,7 +41,7 @@ class FairStep(RdfWrapper):
             force: Toggle forcing creation of object even if url is not in any of the subjects of
                 the passed RDF
         """
-        cls._uri_is_subject_in_rdf(uri, rdf, raise_error=(not force))
+        cls._uri_is_subject_in_rdf(uri, rdf, force=force)
         self = cls(uri)
         self._rdf = rdf
         self.anonymise_rdf()

--- a/fairworkflows/fairstep.py
+++ b/fairworkflows/fairstep.py
@@ -2,10 +2,8 @@ import inspect
 import time
 import warnings
 from typing import List
-from urllib.parse import urldefrag
 
 import rdflib
-from nanopub import NanopubClient
 from rdflib import RDF, DCTERMS
 
 from fairworkflows import namespaces

--- a/fairworkflows/fairworkflow.py
+++ b/fairworkflows/fairworkflow.py
@@ -37,14 +37,14 @@ class FairWorkflow(RdfWrapper):
 
     @classmethod
     def from_rdf(cls, rdf: rdflib.Graph, uri: str = None,
-                 fetch_steps: bool = False):
+                 fetch_references: bool = False):
         """Construct Fair Workflow from existing RDF.
 
         Args:
             rdf: RDF graph containing information about the workflow and
                 possibly it's associated steps. Should use plex ontology.
             uri: URI of the workflow
-            fetch_steps: toggles fetching steps. I.e. if we encounter steps
+            fetch_references: toggles fetching steps. I.e. if we encounter steps
                 that are part of the workflow, but are not specified in the
                 RDF we try fetching them from nanopub
         """
@@ -53,7 +53,7 @@ class FairWorkflow(RdfWrapper):
             warnings.warn(f"Warning: Provided URI '{uri}' does not "
                           f"match any subject in provided rdf graph.")
         self = cls(uri=uri)
-        self._extract_steps(rdf, uri, fetch_steps)
+        self._extract_steps(rdf, uri, fetch_references)
         self._rdf = rdf
         self.anonymise_rdf()
         return self

--- a/fairworkflows/fairworkflow.py
+++ b/fairworkflows/fairworkflow.py
@@ -37,7 +37,7 @@ class FairWorkflow(RdfWrapper):
 
     @classmethod
     def from_rdf(cls, rdf: rdflib.Graph, uri: str = None,
-                 fetch_references: bool = False):
+                 fetch_references: bool = False, force: bool = False):
         """Construct Fair Workflow from existing RDF.
 
         Args:
@@ -47,11 +47,11 @@ class FairWorkflow(RdfWrapper):
             fetch_references: toggles fetching steps. I.e. if we encounter steps
                 that are part of the workflow, but are not specified in the
                 RDF we try fetching them from nanopub
+            force: Toggle forcing creation of object even if url is not in any of the subjects of
+                the passed RDF
         """
         rdf = deepcopy(rdf)  # Make sure we don't mutate user RDF
-        if rdflib.URIRef(uri) not in rdf.subjects():
-            warnings.warn(f"Warning: Provided URI '{uri}' does not "
-                          f"match any subject in provided rdf graph.")
+        cls._uri_is_subject_in_rdf(uri, rdf, raise_error=(not force))
         self = cls(uri=uri)
         self._extract_steps(rdf, uri, fetch_references)
         self._rdf = rdf

--- a/fairworkflows/fairworkflow.py
+++ b/fairworkflows/fairworkflow.py
@@ -51,7 +51,7 @@ class FairWorkflow(RdfWrapper):
                 the passed RDF
         """
         rdf = deepcopy(rdf)  # Make sure we don't mutate user RDF
-        cls._uri_is_subject_in_rdf(uri, rdf, raise_error=(not force))
+        cls._uri_is_subject_in_rdf(uri, rdf, force=force)
         self = cls(uri=uri)
         self._extract_steps(rdf, uri, fetch_references)
         self._rdf = rdf

--- a/fairworkflows/rdf_wrapper.py
+++ b/fairworkflows/rdf_wrapper.py
@@ -91,7 +91,7 @@ class RdfWrapper:
     @classmethod
     def from_rdf(cls, rdf: rdflib.Graph, uri: str = None, fetch_references: bool = False):
         """Construct RdfWrapper object from rdf graph.
-        
+
         Args:
             rdf: The RDF graph
             uri: Uri of the object

--- a/fairworkflows/rdf_wrapper.py
+++ b/fairworkflows/rdf_wrapper.py
@@ -3,6 +3,8 @@ import warnings
 import rdflib
 from nanopub import Nanopub, NanopubClient
 
+from fairworkflows import namespaces
+
 
 class RdfWrapper:
     def __init__(self, uri, ref_name='fairobject'):

--- a/fairworkflows/rdf_wrapper.py
+++ b/fairworkflows/rdf_wrapper.py
@@ -104,21 +104,21 @@ class RdfWrapper:
         raise NotImplementedError()
 
     @staticmethod
-    def _uri_is_subject_in_rdf(uri: str, rdf: rdflib.Graph, raise_error: bool):
+    def _uri_is_subject_in_rdf(uri: str, rdf: rdflib.Graph, force: bool):
         """Check whether uri is a subject in the rdf.
 
         Args:
             rdf: The RDF graph
             uri: Uri of the object
-            raise_error: Toggle raising an error or just a warning
+            force: Toggle raising an error (force=False) or just a warning (force=True)
         """
         if rdflib.URIRef(uri) not in rdf.subjects():
             message = (f"Provided URI '{uri}' does not "
                        f"match any subject in provided rdf graph.")
-            if raise_error:
-                raise ValueError(message)
-            else:
+            if force:
                 warnings.warn(message, UserWarning)
+            else:
+                raise ValueError(message + " Use force=True to suppress this error")
 
     @classmethod
     def from_nanopub(cls, uri: str):

--- a/fairworkflows/rdf_wrapper.py
+++ b/fairworkflows/rdf_wrapper.py
@@ -89,7 +89,8 @@ class RdfWrapper:
                 self._rdf.add((s, p, self.self_ref))
 
     @classmethod
-    def from_rdf(cls, rdf: rdflib.Graph, uri: str = None, fetch_references: bool = False):
+    def from_rdf(cls, rdf: rdflib.Graph, uri: str = None, fetch_references: bool = False,
+                 force: bool = False):
         """Construct RdfWrapper object from rdf graph.
 
         Args:
@@ -97,8 +98,27 @@ class RdfWrapper:
             uri: Uri of the object
             fetch_references: Boolean toggling whether to fetch objects from nanopub that are
                 referred by this object (e.g. FairSteps in a FairWorkflow)
+            force: Toggle forcing creation of object even if url is not in any of the subjects of
+                the passed RDF
         """
         raise NotImplementedError()
+
+    @staticmethod
+    def _uri_is_subject_in_rdf(uri: str, rdf: rdflib.Graph, raise_error: bool):
+        """Check whether uri is a subject in the rdf.
+
+        Args:
+            rdf: The RDF graph
+            uri: Uri of the object
+            raise_error: Toggle raising an error or just a warning
+        """
+        if rdflib.URIRef(uri) not in rdf.subjects():
+            message = (f"Provided URI '{uri}' does not "
+                       f"match any subject in provided rdf graph.")
+            if raise_error:
+                raise ValueError(message)
+            else:
+                warnings.warn(message, UserWarning)
 
     @classmethod
     def from_nanopub(cls, uri: str):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/fair-workflows/nanopub.git@fix_introduces_concept
+nanopub==0.2.2
 networkx~=2.5
 pytest
 pyyaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-nanopub==0.2.1
+git+https://github.com/fair-workflows/nanopub.git@fix_introduces_concept
 networkx~=2.5
 pytest
 pyyaml

--- a/tests/test_fairstep.py
+++ b/tests/test_fairstep.py
@@ -102,8 +102,8 @@ class TestFairStep:
         with pytest.raises(AssertionError):
             step.validate()
 
-    @patch('fairworkflows.fairstep.NanopubClient.publish')
-    @patch('fairworkflows.fairstep.NanopubClient.fetch')
+    @patch('fairworkflows.rdf_wrapper.NanopubClient.publish')
+    @patch('fairworkflows.rdf_wrapper.NanopubClient.fetch')
     def test_modification_and_republishing(self, nanopub_fetch_mock,
                                            nanopub_publish_mock):
 

--- a/tests/test_fairstep.py
+++ b/tests/test_fairstep.py
@@ -2,21 +2,11 @@ from unittest.mock import patch
 
 import pytest
 import rdflib
-import requests
 from nanopub import Nanopub
 
+from conftest import skip_if_nanopub_server_unavailable
 from fairworkflows import FairStep
 from fairworkflows.config import TESTS_RESOURCES
-
-BAD_GATEWAY = 502
-NANOPUB_SERVER = 'http://purl.org/np/'
-SERVER_UNAVAILABLE = 'Nanopub server is unavailable'
-
-
-def nanopub_server_unavailable():
-    response = requests.get(NANOPUB_SERVER)
-
-    return response.status_code == BAD_GATEWAY
 
 
 class TestFairStep:
@@ -46,7 +36,7 @@ class TestFairStep:
             assert str(output) == new_output
 
     @pytest.mark.flaky(max_runs=10)
-    @pytest.mark.skipif(nanopub_server_unavailable(), reason=SERVER_UNAVAILABLE)
+    @skip_if_nanopub_server_unavailable
     def test_construction_from_nanopub(self):
         """
             Check that we can load a FairStep from known nanopub URIs for manual steps,
@@ -67,7 +57,7 @@ class TestFairStep:
             assert not step.is_script_task
 
     @pytest.mark.flaky(max_runs=10)
-    @pytest.mark.skipif(nanopub_server_unavailable(), reason=SERVER_UNAVAILABLE)
+    @skip_if_nanopub_server_unavailable
     def test_construction_from_nanopub_without_fragment(self):
         """
             Check that we can load a FairStep from known nanopub URIs also

--- a/tests/test_fairworkflow.py
+++ b/tests/test_fairworkflow.py
@@ -51,6 +51,18 @@ class TestFairWorkflow:
         assert len(workflow.__str__()) > 0
         assert workflow.rdf is not None
 
+    def test_construct_from_rdf_uri_not_in_subjects(self):
+        rdf = self._get_rdf_test_resource('test_workflow_including_steps.trig')
+        # This URI is not in the subject of this RDF:
+        uri = 'http://www.example.org/some-random-uri'
+        with pytest.raises(ValueError):
+            FairWorkflow.from_rdf(rdf, uri, force=False)
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            FairWorkflow.from_rdf(rdf, uri, force=True)
+            assert len(w) == 1
+
     def test_construct_from_rdf_including_steps(self):
         """
         Construct FairWorkflow from RDF that includes detailed information

--- a/tests/test_fairworkflow.py
+++ b/tests/test_fairworkflow.py
@@ -57,7 +57,7 @@ class TestFairWorkflow:
         """
         rdf = self._get_rdf_test_resource('test_workflow_including_steps.trig')
         uri = 'http://www.example.org/workflow1'
-        workflow = FairWorkflow.from_rdf(rdf, uri, fetch_steps=False)
+        workflow = FairWorkflow.from_rdf(rdf, uri, fetch_references=False)
         new_rdf = self._get_rdf_test_resource(
             'test_workflow_including_steps.trig')
         assert rdflib.compare.isomorphic(rdf, new_rdf),\
@@ -80,7 +80,7 @@ class TestFairWorkflow:
         mock_fetch_step.return_value = self.step1
         rdf = self._get_rdf_test_resource('test_workflow_excluding_steps.trig')
         uri = 'http://www.example.org/workflow1'
-        workflow = FairWorkflow.from_rdf(rdf, uri, fetch_steps=True)
+        workflow = FairWorkflow.from_rdf(rdf, uri, fetch_references=True)
         assert len(workflow._steps) == 1
         assert mock_fetch_step.call_count == 1
         assert list(workflow._steps.values())[0] == self.step1
@@ -95,7 +95,7 @@ class TestFairWorkflow:
         uri = 'http://www.example.org/workflow1'
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
-            workflow = FairWorkflow.from_rdf(rdf, uri, fetch_steps=False)
+            workflow = FairWorkflow.from_rdf(rdf, uri, fetch_references=False)
             assert len(w) == 1, 'Exactly 1 warning should be raised'
             assert 'Could not get detailed information' in str(w[0].message)
         assert len(workflow._steps) == 1
@@ -111,7 +111,7 @@ class TestFairWorkflow:
         uri = 'http://www.example.org/workflow1'
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
-            workflow = FairWorkflow.from_rdf(rdf, uri, fetch_steps=True)
+            workflow = FairWorkflow.from_rdf(rdf, uri, fetch_references=True)
             assert len(w) == 1, 'Exactly 1 warning should be raised'
             assert 'Could not get detailed information' in str(w[0].message)
         assert len(workflow._steps) == 1

--- a/tests/test_fairworkflow.py
+++ b/tests/test_fairworkflow.py
@@ -6,6 +6,7 @@ import rdflib
 from rdflib.compare import isomorphic
 from requests import HTTPError
 
+from conftest import skip_if_nanopub_server_unavailable
 from fairworkflows import FairWorkflow, FairStep, add_step
 from fairworkflows.config import TESTS_RESOURCES
 
@@ -115,6 +116,25 @@ class TestFairWorkflow:
             assert len(w) == 1, 'Exactly 1 warning should be raised'
             assert 'Could not get detailed information' in str(w[0].message)
         assert len(workflow._steps) == 1
+
+    @pytest.mark.flaky(max_runs=10)
+    @skip_if_nanopub_server_unavailable
+    def test_construction_from_nanopub(self):
+        """Test loading a FairWorkflow from known nanopub URI."""
+
+        # Test for a url both with fragment specified and without
+        uris = [
+            'http://purl.org/np/RAVtqYmYjLCSdSde4iBPOF98qakyxBg8MgXdh1KBYut0w#plan',
+            'http://purl.org/np/RAVtqYmYjLCSdSde4iBPOF98qakyxBg8MgXdh1KBYut0w'
+        ]
+        for uri in uris:
+            workflow = FairWorkflow.from_nanopub(uri=uri)
+            assert workflow is not None
+            workflow.validate()
+            steps = list(workflow)
+            assert len(steps) > 0
+            for step in steps:
+                step.validate()
 
     @mock.patch('fairworkflows.fairworkflow.FairStep.from_nanopub')
     def test_fetch_step_404(self, mock_from_nanopub):


### PR DESCRIPTION
- Move `from_nanopub` method from FairWorkflow to RdfWrapper class so it can be used both in FairWorkflow and FairStep classes.
- Simplify from_nanopub method by making it depend on from_rdf method
- Add skip_if_nanopub_server_unavailable decorator to conftest so it can be used in multiple test files.