### PR TITLE
Fix bug: #130 Steps without URI are reffered to as <None> in workflow RDF

### DIFF
--- a/fairworkflows/fairstep.py
+++ b/fairworkflows/fairstep.py
@@ -29,14 +29,14 @@ class FairVariable:
     Args:
         name: The name of the variable (and of the blank node in RDF that this variable is
             represented with)
-        uri: Optionally pass a uri that the variable is referred to, the variable name will be
+        step_ref: Optionally pass a step_ref that the variable is referred to, the variable name will be
             automatically extracted from it. This argument is usually only used when we extract a
             variable from rdf)
         type: The type of the variable (i.e. int, str, float etc.)
     """
     def __init__(self, name: str = None, type: str = None, uri: str = None):
         if uri and name is None:
-            # Get the name from the uri (i.e. 'input1' from http://example.org#input1)
+            # Get the name from the step_ref (i.e. 'input1' from http://example.org#input1)
             _, name = urldefrag(uri)
         self.name = name
         self.type = type
@@ -77,10 +77,10 @@ class FairStep(RdfWrapper):
     """
 
     def __init__(self, label: str = None, description: str = None, uri=None,
-                 is_pplan_step: bool = True, is_manual_task: bool = None,
+                 id: str = None, is_pplan_step: bool = True, is_manual_task: bool = None,
                  is_script_task: bool = None, inputs: List[FairVariable] = None,
                  outputs: List[FairVariable] = None, derived_from=None):
-        super().__init__(uri=uri, ref_name='step', derived_from=derived_from)
+        super().__init__(uri=uri, id=id, derived_from=derived_from)
         if label is not None:
             self.label = label
         if description is not None:
@@ -130,7 +130,7 @@ class FairStep(RdfWrapper):
         * Filter out the DUL:precedes and PPLAN:isStepOfPlan predicate triples, because they are
             part of a workflow and not of a step.
         * Match all triples that are through an arbitrary-length property path related to the
-            step uri. So if 'URI predicate Something', then all triples 'Something predicate
+            step step_ref. So if 'URI predicate Something', then all triples 'Something predicate
             object' are selected, and so forth.
         """
         # Remove workflow-related triples from the graph, they effectively make other steps or
@@ -144,7 +144,7 @@ class FairStep(RdfWrapper):
         WHERE {
             ?s ?p ?o .
             # Match all triples that are through an arbitrary-length property path related to the
-            # step uri. (<>|!<>) matches all predicates. Binding to step_uri is done when executing.
+            # step step_ref. (<>|!<>) matches all predicates. Binding to step_uri is done when executing.
             ?step_uri (<>|!<>)* ?s .
         }
         """

--- a/tests/test_fairstep.py
+++ b/tests/test_fairstep.py
@@ -62,6 +62,12 @@ class TestFairStep:
         step.is_script_task = False  # Test setting to current value
         assert not step.is_script_task
 
+    def test_unique_step_identifiers(self):
+        step1 = FairStep()
+        step2 = FairStep()
+        assert step1.id != step2.id
+        assert step1.self_ref != step2.self_ref
+
     def test_construction_from_rdf(self):
         rdf = read_rdf_test_resource('sample_fairstep_nanopub.trig')
         uri = 'http://purl.org/np/RACLlhNijmCk4AX_2PuoBPHKfY1T6jieGaUPVFv-fWCAg#step'

--- a/tests/test_fairworkflow.py
+++ b/tests/test_fairworkflow.py
@@ -69,6 +69,13 @@ class TestFairWorkflow:
         assert len(workflow.__str__()) > 0
         assert workflow.rdf is not None
 
+    def test_build_workflow_including_step_without_uri(self):
+        step1 = FairStep()
+        workflow = FairWorkflow()
+        workflow.add(step1)
+        assert (rdflib.URIRef(step1.self_ref), None, None) in workflow.rdf
+        assert (None, None, rdflib.URIRef(step1.self_ref)) in workflow.rdf
+
     def test_construct_from_rdf_uri_not_in_subjects(self):
         rdf = read_rdf_test_resource('test_workflow_including_steps.trig')
         # This URI is not in the subject of this RDF:
@@ -128,7 +135,7 @@ class TestFairWorkflow:
         """
         Construct FairWorkflow from RDF that only includes URIs that point to
         steps. We choose not to fetch these steps and have empty fair steps
-        pointing to the uri.
+        pointing to the step_ref.
         """
         rdf = read_rdf_test_resource('test_workflow_excluding_steps.trig')
         uri = 'http://www.example.org/workflow1'


### PR DESCRIPTION
Use unique ids for RdfWrapper objects and refer to the now-unique step.self_ref in workflow