### PR TITLE
Throw TypeError if workflow does not return a promise

### DIFF
--- a/fairworkflows/fairworkflow.py
+++ b/fairworkflows/fairworkflow.py
@@ -7,6 +7,7 @@ from typing import Iterator, Optional
 
 import networkx as nx
 import rdflib
+from noodles.interface import PromisedObject
 from rdflib import RDF, RDFS, DCTERMS
 from rdflib.tools.rdf2dot import rdf2dot
 from requests import HTTPError
@@ -511,6 +512,9 @@ def is_fairworkflow(label: str = None, is_pplan_plan: bool = True):
         """
         def _wrapper(*args, **kwargs):
             promise = func(*args, **kwargs)
+            if not isinstance(promise, PromisedObject):
+                raise TypeError("The workflow does not return a 'promise'. Did you use the "
+                                "is_fairstep decorator on all the steps?")
 
             # Description of workflow is the raw function code
             description = inspect.getsource(func)

--- a/tests/test_fairworkflow.py
+++ b/tests/test_fairworkflow.py
@@ -386,7 +386,7 @@ class TestFairWorkflow:
             my_workflow(1, 2)
         assert "The workflow does not return a 'promise'" in str(e.value)
 
-    def test_workflow_non_decorated_steps(self):
+    def test_workflow_mixed_decorated_steps(self):
         def add(a: float, b: float) -> float:
             """Adding up numbers. NB: no is_fairstep decorator!"""
             return a + b

--- a/tests/test_fairworkflow.py
+++ b/tests/test_fairworkflow.py
@@ -370,3 +370,38 @@ class TestFairWorkflow:
         #assert isinstance(result, type(obj))
         #assert result.message == obj.message
         #assert isinstance(prov, Publication)
+
+    def test_workflow_non_decorated_step(self):
+        def add(a: float, b: float) -> float:
+            """Adding up numbers. NB: no is_fairstep decorator!"""
+            return a + b
+
+        @is_fairworkflow(label='My Workflow')
+        def my_workflow(in1, in2):
+            """
+            A simple addition workflow
+            """
+            return add(in1, in2)
+        with pytest.raises(TypeError) as e:
+            my_workflow(1, 2)
+        assert "The workflow does not return a 'promise'" in str(e.value)
+
+    def test_workflow_non_decorated_steps(self):
+        def add(a: float, b: float) -> float:
+            """Adding up numbers. NB: no is_fairstep decorator!"""
+            return a + b
+
+        @is_fairstep(label='Subtraction')
+        def sub(a: float, b: float) -> float:
+            """Subtracting numbers."""
+            return a - b
+
+        @is_fairworkflow(label='My Workflow')
+        def my_workflow(in1, in2):
+            """
+            A simple addition, subtraction workflow
+            """
+            return add(in1, sub(in2, in2))
+
+        fw = my_workflow(1, 2)
+        assert isinstance(fw, FairWorkflow)

--- a/tests/test_fairworkflow.py
+++ b/tests/test_fairworkflow.py
@@ -385,23 +385,3 @@ class TestFairWorkflow:
         with pytest.raises(TypeError) as e:
             my_workflow(1, 2)
         assert "The workflow does not return a 'promise'" in str(e.value)
-
-    def test_workflow_mixed_decorated_steps(self):
-        def add(a: float, b: float) -> float:
-            """Adding up numbers. NB: no is_fairstep decorator!"""
-            return a + b
-
-        @is_fairstep(label='Subtraction')
-        def sub(a: float, b: float) -> float:
-            """Subtracting numbers."""
-            return a - b
-
-        @is_fairworkflow(label='My Workflow')
-        def my_workflow(in1, in2):
-            """
-            A simple addition, subtraction workflow
-            """
-            return add(in1, sub(in2, in2))
-
-        fw = my_workflow(1, 2)
-        assert isinstance(fw, FairWorkflow)


### PR DESCRIPTION
This solves some cases of users using the `is_fairworkflow` on a workflow that does not return a promise. It still allows non-decorated functions to be part of the workflow though which might fail with confusing error messages or pass but then we cannot get all the provenance (See the failing test `test_workflow_mixed_decorated_steps`). 

In theory we could check if all functions are decorated with the `is_fairstep` decorator, something like [this](https://stackoverflow.com/questions/51901676/get-the-lists-of-functions-used-called-within-a-function-in-python). But it is rather ugly and complex so I vote against it.

I decided to solve that later, see https://github.com/fair-workflows/fairworkflows/issues/150#issuecomment-771713201 , meanwhile I think we should merge this one.