### PR TITLE
Bind the input arguments to the execute method

### DIFF
--- a/fairworkflows/fairstep.py
+++ b/fairworkflows/fairstep.py
@@ -169,8 +169,7 @@ class FairStep(RdfWrapper):
     @classmethod
     def from_function(cls, func: Callable):
         """
-        Generates a plex rdf decription for the given python function,
-        and makes this FairStep object a bpmn:ScriptTask.
+        Return a FairStep object for a function decorated with is_fairstep decorator
         """
         try:
             return func._fairstep

--- a/fairworkflows/fairstep.py
+++ b/fairworkflows/fairstep.py
@@ -176,7 +176,7 @@ class FairStep(RdfWrapper):
             return func._fairstep
         except AttributeError:
             raise ValueError('The function was not marked as a fair step,'
-                             'use mark_as_fairstep decorator to mark it.')
+                             'use is_fairworkflow decorator to mark it.')
 
     @property
     def is_pplan_step(self):

--- a/fairworkflows/fairworkflow.py
+++ b/fairworkflows/fairworkflow.py
@@ -527,7 +527,7 @@ def is_fairworkflow(label: str = None, is_pplan_plan: bool = True):
         num_params = len(inspect.signature(func).parameters)
         empty_args = ([inspect.Parameter.empty()] * num_params)
         promise = scheduled_workflow(*empty_args)
-        if not isinstance(promise, PromisedObject):
+        if not isinstance(func(*empty_args), PromisedObject):
             raise TypeError("The workflow does not return a 'promise'. Did you use the "
                             "is_fairstep decorator on all the steps?")
 

--- a/fairworkflows/fairworkflow.py
+++ b/fairworkflows/fairworkflow.py
@@ -91,8 +91,7 @@ class FairWorkflow(RdfWrapper):
         self = cls(description=description, label=label, is_pplan_plan=is_pplan_plan, derived_from=derived_from)
         self.noodles_promise = noodles_promise
 
-        from noodles import get_workflow
-        workflow = get_workflow(self.noodles_promise)
+        workflow = noodles.get_workflow(self.noodles_promise)
 
         # Exclude the root, because that is the workflow definition itself and not a step
         steps_dict = {i: n.foo._fairstep for i, n in workflow.nodes.items() if i != workflow.root}
@@ -105,7 +104,6 @@ class FairWorkflow(RdfWrapper):
             if i == workflow.root:
                 continue
             current_step = steps_dict[i]
-            # Some of this is retro prov
             from_uri = rdflib.URIRef(steps_dict[i].uri + '#' + current_step.outputs[0].name)
             for j in workflow.links[i]:
                 linked_step = steps_dict[j[0]]

--- a/fairworkflows/fairworkflow.py
+++ b/fairworkflows/fairworkflow.py
@@ -76,8 +76,7 @@ class FairWorkflow(RdfWrapper):
     @classmethod
     def from_function(cls, func: Callable):
         """
-        Generates a plex rdf decription for the given python function,
-        and makes this FairStep object a bpmn:ScriptTask.
+        Return a FairWorkflow object for a function decorated with is_fairworkflow decorator
         """
         try:
             return func._fairworkflow

--- a/fairworkflows/fairworkflow.py
+++ b/fairworkflows/fairworkflow.py
@@ -355,7 +355,7 @@ class FairWorkflow(RdfWrapper):
         if full_rdf:
             return self.display_full_rdf()
         else:
-            if not hasattr(self, 'promise'):
+            if not hasattr(self, 'noodles_promise'):
                 raise ValueError('Cannot display workflow as no noodles promise has been constructed.')
             import noodles.tutorial
             noodles.tutorial.display_workflows(prefix='control', workflow=self.noodles_promise)

--- a/fairworkflows/fairworkflow.py
+++ b/fairworkflows/fairworkflow.py
@@ -5,7 +5,7 @@ import warnings
 from copy import deepcopy
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Iterator, Optional
+from typing import Iterator, Optional, Callable
 
 import nanopub
 import networkx as nx
@@ -72,6 +72,18 @@ class FairWorkflow(RdfWrapper):
             self._rdf = deepcopy(rdf)  # Make sure we don't mutate user RDF
         self.anonymise_rdf()
         return self
+
+    @classmethod
+    def from_function(cls, func: Callable):
+        """
+        Generates a plex rdf decription for the given python function,
+        and makes this FairStep object a bpmn:ScriptTask.
+        """
+        try:
+            return func._fairworkflow
+        except AttributeError:
+            raise ValueError('The function was not marked as a fair workflow,'
+                             'use is_fairworkflow decorator to mark it.')
 
     @classmethod
     def from_noodles_promise(cls, noodles_promise, description: str = None, label: str = None,

--- a/fairworkflows/fairworkflow.py
+++ b/fairworkflows/fairworkflow.py
@@ -379,7 +379,7 @@ class FairWorkflow(RdfWrapper):
         workflow and retroprov is the retrospective provenance logged during execution.
         """
 
-        if not hasattr(self, 'promise'):
+        if not hasattr(self, 'noodles_promise'):
             raise ValueError('Cannot execute workflow as no noodles promise has been constructed.')
 
         log = io.StringIO()

--- a/tests/test_fairworkflow.py
+++ b/tests/test_fairworkflow.py
@@ -1,3 +1,4 @@
+import inspect
 import warnings
 from unittest import mock
 
@@ -336,18 +337,18 @@ class TestFairWorkflow:
             """
             A simple addition, subtraction, multiplication workflow
             """
-            t1 = add(in1, in2)
-            t2 = sub(in1, in2)
-            t3 = mul(weird(t1, in3), t2)
-            return t3
+            t1 = add(in1, in2)  # 5
+            t2 = sub(in1, in2)  # -3
+            t3 = weird(t1, in3)  # 10 + 12 = 22
+            t4 = mul(t3, t2)  # 22 * -3 =
+            return t4
 
-        fw = my_workflow(1, 4, 3)
+        fw = my_workflow._fairworkflow
         assert isinstance(fw, FairWorkflow)
 
-        # TODO: Find out why execution hangs only when running in pytest. May be to do with the threading.
-        #result, prov = fw.execute(num_threads=1)
-        #assert result == -66
-        #assert isinstance(prov, Publication)
+        result, prov = fw.execute(1, 4, 3)
+        assert result == -66
+        assert isinstance(prov, Publication)
 
     def test_workflow_complex_serialization(self):
         class OtherType:
@@ -363,10 +364,18 @@ class TestFairWorkflow:
             return return_that_object(im)
 
         obj = OtherType('I could be e.g. a PIL Image')
-        fw = process_image(obj)
+        fw = process_image._fairworkflow
+        result, prov = fw.execute(obj)
+        assert isinstance(result, type(obj))
+        assert result.message == obj.message
+        assert isinstance(prov, Publication)
 
-        # TODO: Find out why execution hangs only when running in pytest. May be to do with the threading.
-        #result, prov = fw.execute()
-        #assert isinstance(result, type(obj))
-        #assert result.message == obj.message
-        #assert isinstance(prov, Publication)
+    def test_get_arguments_dict(self):
+        args = (1, 2)
+        kwargs = {'c': 3, 'd': 4}
+
+        def func(a, b, c, d):
+            return
+
+        result = FairWorkflow._get_arguments_dict(args, kwargs, inspect.signature(func))
+        assert result == {'a': 1, 'b': 2, 'c': 3, 'd': 4}

--- a/tests/test_fairworkflow.py
+++ b/tests/test_fairworkflow.py
@@ -381,16 +381,15 @@ class TestFairWorkflow:
         assert result == {'a': 1, 'b': 2, 'c': 3, 'd': 4}
 
     def test_workflow_non_decorated_step(self):
-        def add(a: float, b: float) -> float:
-            """Adding up numbers. NB: no is_fairstep decorator!"""
-            return a + b
+        def return_value(a: float) -> float:
+            """Return the input value. NB: no is_fairstep decorator!"""
+            return a
 
-        @is_fairworkflow(label='My Workflow')
-        def my_workflow(in1, in2):
-            """
-            A simple addition workflow
-            """
-            return add(in1, in2)
         with pytest.raises(TypeError) as e:
-            my_workflow(1, 2)
+            @is_fairworkflow(label='My Workflow')
+            def my_workflow(in1):
+                """
+                A simple workflow
+                """
+                return return_value(in1)
         assert "The workflow does not return a 'promise'" in str(e.value)

--- a/tests/test_fairworkflow.py
+++ b/tests/test_fairworkflow.py
@@ -11,6 +11,7 @@ from fairworkflows import FairWorkflow, FairStep, namespaces, FairVariable, is_f
 from fairworkflows.rdf_wrapper import replace_in_rdf
 from nanopub import Publication
 
+
 class TestFairWorkflow:
     test_description = 'This is a test workflow.'
     test_label = 'Test'
@@ -340,10 +341,11 @@ class TestFairWorkflow:
             t1 = add(in1, in2)  # 5
             t2 = sub(in1, in2)  # -3
             t3 = weird(t1, in3)  # 10 + 12 = 22
-            t4 = mul(t3, t2)  # 22 * -3 =
+            t4 = mul(t3, t2)  # 22 * -3 = 66
             return t4
 
-        fw = my_workflow._fairworkflow
+        fw = FairWorkflow.from_function(my_workflow)
+
         assert isinstance(fw, FairWorkflow)
 
         result, prov = fw.execute(1, 4, 3)
@@ -364,7 +366,7 @@ class TestFairWorkflow:
             return return_that_object(im)
 
         obj = OtherType('I could be e.g. a PIL Image')
-        fw = process_image._fairworkflow
+        fw = FairWorkflow.from_function(process_image)
         result, prov = fw.execute(obj)
         assert isinstance(result, type(obj))
         assert result.message == obj.message


### PR DESCRIPTION
I now bind the input arguments when we execute the fair workflow, instead of when we define the workflow. That closes #160.

I had to rely on `run_single` so the execution tests work. This breaks retro prov tracking. I created an issue for that: #168