### PR TITLE
Issue164 add language to rdf

### DIFF
--- a/examples/noodles_fw.ipynb
+++ b/examples/noodles_fw.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "greatest-portland",
    "metadata": {},
    "source": [
     "# FairWorkflows execution demo"
@@ -9,6 +10,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "hawaiian-colon",
    "metadata": {},
    "source": [
     "## Define the steps of your workflow\n",
@@ -17,16 +19,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 1,
+   "id": "criminal-cleaners",
    "metadata": {},
    "outputs": [],
    "source": [
-    "from fairworkflows import is_fairworkflow, is_fairstep, FairWorkflow"
+    "from fairworkflows import is_fairworkflow, is_fairstep, FairStep, FairWorkflow"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
+   "id": "english-participation",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -39,6 +43,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
+   "id": "bound-greensboro",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -51,6 +56,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
+   "id": "dietary-stroke",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -63,6 +69,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
+   "id": "positive-profession",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -75,6 +82,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "orange-gothic",
    "metadata": {},
    "source": [
     "## Define your workflow using @fairworkflow\n",
@@ -83,7 +91,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 9,
+   "id": "weighted-operation",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -100,6 +109,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "clinical-mobile",
    "metadata": {},
    "source": [
     "## Create an instance of your workflow and display it"
@@ -108,6 +118,7 @@
   {
    "cell_type": "code",
    "execution_count": 10,
+   "id": "worst-reply",
    "metadata": {},
    "outputs": [
     {
@@ -128,20 +139,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 11,
+   "id": "working-hearing",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Workflow URI = http://purl.org/np/RAWarWs5kFRYx0vtzhYPrl9xzY53MKDEfzYMp09fZGEWY#plan\n",
+      "Workflow URI = None\n",
       "@prefix ns1: <http://purl.org/dc/terms/> .\n",
       "@prefix pplan: <http://purl.org/net/p-plan#> .\n",
       "@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n",
       "\n",
-      "_:Ne234b6e53c0f40bdbdc81abe5c4feba2 {\n",
-      "    <http://purl.org/nanopub/temp/mynanopub#plan> a pplan:Plan ;\n",
+      "_:N8debcd32a01c44bf96071a7521751bcf {\n",
+      "    [] a pplan:Plan ;\n",
       "        rdfs:label \"My Workflow\" ;\n",
       "        ns1:description \"\"\"@is_fairworkflow(label='My Workflow')\n",
       "def my_workflow(in1, in2, in3):\n",
@@ -165,6 +177,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "capable-occasion",
    "metadata": {},
    "source": [
     "## Publish the (prospective) workflow\n",
@@ -173,7 +186,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 12,
+   "id": "senior-badge",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -182,6 +196,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "polyphonic-capability",
    "metadata": {},
    "source": [
     "Be warned though - the above will keep publishing to the 'real' nanopub server network. For testing you may prefer to publish to the test servers as follows (note that this will refuse to publish a workflow you have already published :"
@@ -189,25 +204,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
+   "id": "quick-gothic",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Published to http://purl.org/np/RAWarWs5kFRYx0vtzhYPrl9xzY53MKDEfzYMp09fZGEWY\n",
-      "Published concept to http://purl.org/np/RAWarWs5kFRYx0vtzhYPrl9xzY53MKDEfzYMp09fZGEWY#plan\n"
+      "Published to http://purl.org/np/RArXfC72LtqYAYT-_v93KOBWxHdJTUlgofCuhFN6aA7Cg\n",
+      "Published concept to http://purl.org/np/RArXfC72LtqYAYT-_v93KOBWxHdJTUlgofCuhFN6aA7Cg#plan\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "{'nanopub_uri': 'http://purl.org/np/RAWarWs5kFRYx0vtzhYPrl9xzY53MKDEfzYMp09fZGEWY',\n",
-       " 'concept_uri': 'http://purl.org/np/RAWarWs5kFRYx0vtzhYPrl9xzY53MKDEfzYMp09fZGEWY#plan'}"
+       "{'nanopub_uri': 'http://purl.org/np/RArXfC72LtqYAYT-_v93KOBWxHdJTUlgofCuhFN6aA7Cg',\n",
+       " 'concept_uri': 'http://purl.org/np/RArXfC72LtqYAYT-_v93KOBWxHdJTUlgofCuhFN6aA7Cg#plan'}"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -218,6 +234,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "built-warren",
    "metadata": {},
    "source": [
     "You can then find your nanopublications by replacing the base of the URI with http://test-server.nanopubs.lod.labs.vu.nl/"
@@ -225,6 +242,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "hybrid-stuff",
    "metadata": {},
    "source": [
     "## Execute your workflow using .execute()\n",
@@ -233,7 +251,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
+   "id": "french-disposal",
    "metadata": {},
    "outputs": [
     {
@@ -242,7 +261,7 @@
        "-66"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -254,6 +273,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "french-entrepreneur",
    "metadata": {},
    "source": [
     " ## Retrospective prov\n",
@@ -264,7 +284,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
+   "id": "sonic-causing",
    "metadata": {},
    "outputs": [
     {
@@ -273,7 +294,7 @@
        "nanopub.publication.Publication"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -284,7 +305,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
+   "id": "organizational-antarctica",
    "metadata": {},
    "outputs": [
     {
@@ -298,14 +320,13 @@
       "@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n",
       "@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n",
       "\n",
-      ":assertion {\n",
-      "    :retroprov a prov:Activity ;\n",
-      "        rdfs:label \"\" ;\n",
-      "        prov:wasDerivedFrom <http://purl.org/np/RAWarWs5kFRYx0vtzhYPrl9xzY53MKDEfzYMp09fZGEWY#plan> .\n",
+      ":provenance {\n",
+      "    :assertion prov:generatedAtTime \"2021-02-09T11:56:08.499705\"^^xsd:dateTime .\n",
       "}\n",
       "\n",
-      ":provenance {\n",
-      "    :assertion prov:generatedAtTime \"2021-02-09T07:26:44.473167\"^^xsd:dateTime .\n",
+      ":pubInfo {\n",
+      "    : prov:generatedAtTime \"2021-02-09T11:56:08.499705\"^^xsd:dateTime ;\n",
+      "        prov:wasAttributedTo <https://orcid.org/0000-0000-0000-0000> .\n",
       "}\n",
       "\n",
       ":Head {\n",
@@ -315,9 +336,10 @@
       "        np:hasPublicationInfo :pubInfo .\n",
       "}\n",
       "\n",
-      ":pubInfo {\n",
-      "    : prov:generatedAtTime \"2021-02-09T07:26:44.473167\"^^xsd:dateTime ;\n",
-      "        prov:wasAttributedTo <https://orcid.org/1234-1234-1234-1234> .\n",
+      ":assertion {\n",
+      "    :retroprov a prov:Activity ;\n",
+      "        rdfs:label \"\" ;\n",
+      "        prov:wasDerivedFrom <http://purl.org/np/RArXfC72LtqYAYT-_v93KOBWxHdJTUlgofCuhFN6aA7Cg#plan> .\n",
       "}\n",
       "\n",
       "\n"
@@ -330,6 +352,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "adjusted-eugene",
    "metadata": {},
    "source": [
     "### Provide semantic annotations for input and output variables\n",
@@ -339,7 +362,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 17,
+   "id": "difficult-valuable",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -350,6 +374,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "alone-clone",
    "metadata": {},
    "source": [
     "If we now look at the RDF generated for the step, we will see that input parameter 'a' and the step output ('out1') both have the (additional) semantic types specified."
@@ -357,7 +382,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 18,
+   "id": "enabling-printing",
    "metadata": {},
    "outputs": [
     {
@@ -366,18 +392,14 @@
      "text": [
       "Step URI = http://www.example.org/unpublished-add\n",
       "@prefix bpmn: <http://dkm.fbk.eu/index.php/BPMN2_Ontology#> .\n",
-      "@prefix ns1: <http://purl.org/dc/terms/> .\n",
       "@prefix pplan: <http://purl.org/net/p-plan#> .\n",
       "@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n",
+      "@prefix schema: <https://schema.org/> .\n",
       "\n",
-      "_:Nda081d4e75bc47f0a65dc6134c6ca5e0 {\n",
+      "_:Ndeffc94ed0864503a93f312204ec3ef4 {\n",
       "    [] a bpmn:ScriptTask,\n",
       "            pplan:Step ;\n",
       "        rdfs:label \"Addition\" ;\n",
-      "        ns1:description \"\"\"@is_fairstep(label='Addition', a='http://www.example.org/distance', out='http://www.example.org/mass')\n",
-      "def add(a:float, b:float) -> float:\n",
-      "    return a + b\n",
-      "\"\"\" ;\n",
       "        pplan:hasInputVar [ a pplan:Variable,\n",
       "                    <http://www.example.org/distance> ;\n",
       "                rdfs:label \"a\" ;\n",
@@ -388,7 +410,12 @@
       "        pplan:hasOutputVar [ a pplan:Variable,\n",
       "                    <http://www.example.org/mass> ;\n",
       "                rdfs:label \"out1\" ;\n",
-      "                rdfs:comment \"float\" ] .\n",
+      "                rdfs:comment \"float\" ] ;\n",
+      "        schema:SoftwareSourceCode [ schema:programmingLanguage \"python 3.8.6\" ;\n",
+      "                schema:text \"\"\"@is_fairstep(label='Addition', a='http://www.example.org/distance', returns='http://www.example.org/mass')\n",
+      "def add(a:float, b:float) -> float:\n",
+      "    return a + b\n",
+      "\"\"\" ] .\n",
       "}\n",
       "\n",
       "\n"
@@ -403,6 +430,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "numeric-fraction",
    "metadata": {},
    "source": [
     "### Specify more than one semantic type for a parameter\n",
@@ -411,18 +439,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 19,
+   "id": "textile-prayer",
    "metadata": {},
    "outputs": [],
    "source": [
     "@is_fairstep(label='Addition', a=['http://www.example.org/distance', 'http://www.example.org/number'])\n",
     "def another_step(a:float, b:float) -> float:\n",
+    "    \"\"\"Add two numbers together\"\"\"\n",
     "    return a + b"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 20,
+   "id": "documented-prophet",
    "metadata": {},
    "outputs": [
     {
@@ -434,15 +465,13 @@
       "@prefix ns1: <http://purl.org/dc/terms/> .\n",
       "@prefix pplan: <http://purl.org/net/p-plan#> .\n",
       "@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n",
+      "@prefix schema: <https://schema.org/> .\n",
       "\n",
-      "_:N94e43cf479454578b20e9b3b1efd89ca {\n",
+      "_:N0d1f7767ca63487b8c06fd9d6e923b44 {\n",
       "    [] a bpmn:ScriptTask,\n",
       "            pplan:Step ;\n",
       "        rdfs:label \"Addition\" ;\n",
-      "        ns1:description \"\"\"@is_fairstep(label='Addition', a=['http://www.example.org/distance', 'http://www.example.org/number'])\n",
-      "def another_step(a:float, b:float) -> float:\n",
-      "    return a + b\n",
-      "\"\"\" ;\n",
+      "        ns1:description \"Add two numbers together\" ;\n",
       "        pplan:hasInputVar [ a pplan:Variable,\n",
       "                    <http://www.example.org/distance>,\n",
       "                    <http://www.example.org/number> ;\n",
@@ -453,7 +482,13 @@
       "                rdfs:comment \"float\" ] ;\n",
       "        pplan:hasOutputVar [ a pplan:Variable ;\n",
       "                rdfs:label \"out1\" ;\n",
-      "                rdfs:comment \"float\" ] .\n",
+      "                rdfs:comment \"float\" ] ;\n",
+      "        schema:SoftwareSourceCode [ schema:programmingLanguage \"python 3.8.6\" ;\n",
+      "                schema:text \"\"\"@is_fairstep(label='Addition', a=['http://www.example.org/distance', 'http://www.example.org/number'])\n",
+      "def another_step(a:float, b:float) -> float:\n",
+      "    \\\"\\\"\\\"Add two numbers together\\\"\\\"\\\"\n",
+      "    return a + b\n",
+      "\"\"\" ] .\n",
       "}\n",
       "\n",
       "\n"
@@ -466,6 +501,36 @@
   },
   {
    "cell_type": "markdown",
+   "id": "binding-salon",
+   "metadata": {},
+   "source": [
+    "You can check the programming language that was used for writing the step:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "prime-monroe",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'python 3.8.6'"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "another_step._fairstep.programming_language"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "statutory-waste",
    "metadata": {},
    "source": [
     "## Semantic types for function producing multiple outputs\n",
@@ -474,7 +539,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 18,
+   "id": "frequent-stanford",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -486,7 +552,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 19,
+   "id": "russian-removal",
    "metadata": {},
    "outputs": [
     {
@@ -495,18 +562,14 @@
      "text": [
       "Step URI = http://www.example.org/unpublished-another_step\n",
       "@prefix bpmn: <http://dkm.fbk.eu/index.php/BPMN2_Ontology#> .\n",
-      "@prefix ns1: <http://purl.org/dc/terms/> .\n",
       "@prefix pplan: <http://purl.org/net/p-plan#> .\n",
       "@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n",
+      "@prefix schema: <https://schema.org/> .\n",
       "\n",
-      "_:Nbfca224ce79741f685b6430a1cdb1d74 {\n",
+      "_:N5eacfe45c1cd43abae42457dcf83cfdc {\n",
       "    [] a bpmn:ScriptTask,\n",
       "            pplan:Step ;\n",
       "        rdfs:label \"Addition and subtraction\" ;\n",
-      "        ns1:description \"\"\"@is_fairstep(label='Addition and subtraction', returns=('http://www.example.org/distance', 'http://www.example.org/number'))\n",
-      "def another_step(a:float, b:float) -> Tuple[float, float]:\n",
-      "    return a + b, a - b\n",
-      "\"\"\" ;\n",
       "        pplan:hasInputVar [ a pplan:Variable ;\n",
       "                rdfs:label \"a\" ;\n",
       "                rdfs:comment \"float\" ],\n",
@@ -520,7 +583,12 @@
       "            [ a pplan:Variable,\n",
       "                    <http://www.example.org/number> ;\n",
       "                rdfs:label \"out2\" ;\n",
-      "                rdfs:comment \"float\" ] .\n",
+      "                rdfs:comment \"float\" ] ;\n",
+      "        schema:SoftwareSourceCode [ schema:programmingLanguage \"python 3.8.6\" ;\n",
+      "                schema:text \"\"\"@is_fairstep(label='Addition and subtraction', returns=('http://www.example.org/distance', 'http://www.example.org/number'))\n",
+      "def another_step(a:float, b:float) -> Tuple[float, float]:\n",
+      "    return a + b, a - b\n",
+      "\"\"\" ] .\n",
       "}\n",
       "\n",
       "\n"
@@ -533,6 +601,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "atlantic-moses",
    "metadata": {},
    "source": [
     "As before, you may provide a list of URIs for each output. If you do not want to provide semantic types for a particular output, simply pass None:"
@@ -541,6 +610,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
+   "id": "approximate-cheat",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -553,6 +623,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
+   "id": "spanish-duration",
    "metadata": {},
    "outputs": [
     {
@@ -600,6 +671,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "critical-processor",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -621,7 +693,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.9"
+   "version": "3.8.6"
   }
  },
  "nbformat": 4,

--- a/examples/noodles_fw.ipynb
+++ b/examples/noodles_fw.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "greatest-portland",
+   "id": "deluxe-relaxation",
    "metadata": {},
    "source": [
     "# FairWorkflows execution demo"
@@ -10,7 +10,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "hawaiian-colon",
+   "id": "exposed-tours",
    "metadata": {},
    "source": [
     "## Define the steps of your workflow\n",
@@ -20,7 +20,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "criminal-cleaners",
+   "id": "gentle-restriction",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -30,7 +30,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "english-participation",
+   "id": "proprietary-brand",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -43,7 +43,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "bound-greensboro",
+   "id": "electoral-enzyme",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -56,7 +56,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "dietary-stroke",
+   "id": "saved-declaration",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -69,7 +69,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "positive-profession",
+   "id": "natural-large",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -82,7 +82,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "orange-gothic",
+   "id": "empty-country",
    "metadata": {},
    "source": [
     "## Define your workflow using @fairworkflow\n",
@@ -91,8 +91,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "id": "weighted-operation",
+   "execution_count": 6,
+   "id": "talented-producer",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -109,7 +109,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "clinical-mobile",
+   "id": "genuine-steel",
    "metadata": {},
    "source": [
     "## Create an instance of your workflow and display it"
@@ -117,8 +117,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "id": "worst-reply",
+   "execution_count": 7,
+   "id": "constitutional-letters",
    "metadata": {},
    "outputs": [
     {
@@ -127,7 +127,7 @@
        "fairworkflows.fairworkflow.FairWorkflow"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -139,8 +139,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "id": "working-hearing",
+   "execution_count": 8,
+   "id": "empty-operator",
    "metadata": {},
    "outputs": [
     {
@@ -148,14 +148,14 @@
      "output_type": "stream",
      "text": [
       "Workflow URI = None\n",
-      "@prefix ns1: <http://purl.org/dc/terms/> .\n",
+      "@prefix dc: <http://purl.org/dc/terms/> .\n",
       "@prefix pplan: <http://purl.org/net/p-plan#> .\n",
       "@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n",
       "\n",
-      "_:N8debcd32a01c44bf96071a7521751bcf {\n",
+      "_:N1eb696cd79a34b9e869accf4efcfd520 {\n",
       "    [] a pplan:Plan ;\n",
       "        rdfs:label \"My Workflow\" ;\n",
-      "        ns1:description \"\"\"@is_fairworkflow(label='My Workflow')\n",
+      "        dc:description \"\"\"@is_fairworkflow(label='My Workflow')\n",
       "def my_workflow(in1, in2, in3):\n",
       "    \\\"\\\"\\\"\n",
       "    A simple addition, subtraction, multiplication workflow\n",
@@ -177,7 +177,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "capable-occasion",
+   "id": "charitable-dublin",
    "metadata": {},
    "source": [
     "## Publish the (prospective) workflow\n",
@@ -186,8 +186,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
-   "id": "senior-badge",
+   "execution_count": 9,
+   "id": "editorial-active",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -196,7 +196,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "polyphonic-capability",
+   "id": "yellow-tradition",
    "metadata": {},
    "source": [
     "Be warned though - the above will keep publishing to the 'real' nanopub server network. For testing you may prefer to publish to the test servers as follows (note that this will refuse to publish a workflow you have already published :"
@@ -204,26 +204,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
-   "id": "quick-gothic",
+   "execution_count": 10,
+   "id": "posted-gabriel",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Published to http://purl.org/np/RArXfC72LtqYAYT-_v93KOBWxHdJTUlgofCuhFN6aA7Cg\n",
-      "Published concept to http://purl.org/np/RArXfC72LtqYAYT-_v93KOBWxHdJTUlgofCuhFN6aA7Cg#plan\n"
+      "Published to http://purl.org/np/RAXo9VWqoJBLVmA0HYSPrwo1DgN5zxMViXIeeLg729w9M\n",
+      "Published concept to http://purl.org/np/RAXo9VWqoJBLVmA0HYSPrwo1DgN5zxMViXIeeLg729w9M#plan\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "{'nanopub_uri': 'http://purl.org/np/RArXfC72LtqYAYT-_v93KOBWxHdJTUlgofCuhFN6aA7Cg',\n",
-       " 'concept_uri': 'http://purl.org/np/RArXfC72LtqYAYT-_v93KOBWxHdJTUlgofCuhFN6aA7Cg#plan'}"
+       "{'nanopub_uri': 'http://purl.org/np/RAXo9VWqoJBLVmA0HYSPrwo1DgN5zxMViXIeeLg729w9M',\n",
+       " 'concept_uri': 'http://purl.org/np/RAXo9VWqoJBLVmA0HYSPrwo1DgN5zxMViXIeeLg729w9M#plan'}"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -234,7 +234,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "built-warren",
+   "id": "nutritional-collection",
    "metadata": {},
    "source": [
     "You can then find your nanopublications by replacing the base of the URI with http://test-server.nanopubs.lod.labs.vu.nl/"
@@ -242,7 +242,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "hybrid-stuff",
+   "id": "animated-investing",
    "metadata": {},
    "source": [
     "## Execute your workflow using .execute()\n",
@@ -251,8 +251,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
-   "id": "french-disposal",
+   "execution_count": 11,
+   "id": "unlimited-shade",
    "metadata": {},
    "outputs": [
     {
@@ -261,7 +261,7 @@
        "-66"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -273,7 +273,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "french-entrepreneur",
+   "id": "loaded-champion",
    "metadata": {},
    "source": [
     " ## Retrospective prov\n",
@@ -284,8 +284,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
-   "id": "sonic-causing",
+   "execution_count": 12,
+   "id": "qualified-soldier",
    "metadata": {},
    "outputs": [
     {
@@ -294,7 +294,7 @@
        "nanopub.publication.Publication"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -305,8 +305,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
-   "id": "organizational-antarctica",
+   "execution_count": 14,
+   "id": "adaptive-belly",
    "metadata": {},
    "outputs": [
     {
@@ -320,13 +320,19 @@
       "@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n",
       "@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n",
       "\n",
-      ":provenance {\n",
-      "    :assertion prov:generatedAtTime \"2021-02-09T11:56:08.499705\"^^xsd:dateTime .\n",
+      ":pubInfo {\n",
+      "    : prov:generatedAtTime \"2021-02-10T13:17:12.646583\"^^xsd:dateTime ;\n",
+      "        prov:wasAttributedTo <https://orcid.org/0000-0000-0000-0000> .\n",
       "}\n",
       "\n",
-      ":pubInfo {\n",
-      "    : prov:generatedAtTime \"2021-02-09T11:56:08.499705\"^^xsd:dateTime ;\n",
-      "        prov:wasAttributedTo <https://orcid.org/0000-0000-0000-0000> .\n",
+      ":provenance {\n",
+      "    :assertion prov:generatedAtTime \"2021-02-10T13:17:12.646583\"^^xsd:dateTime .\n",
+      "}\n",
+      "\n",
+      ":assertion {\n",
+      "    :retroprov a prov:Activity ;\n",
+      "        rdfs:label \"\" ;\n",
+      "        prov:wasDerivedFrom <http://purl.org/np/RAXo9VWqoJBLVmA0HYSPrwo1DgN5zxMViXIeeLg729w9M#plan> .\n",
       "}\n",
       "\n",
       ":Head {\n",
@@ -334,12 +340,6 @@
       "        np:hasAssertion :assertion ;\n",
       "        np:hasProvenance :provenance ;\n",
       "        np:hasPublicationInfo :pubInfo .\n",
-      "}\n",
-      "\n",
-      ":assertion {\n",
-      "    :retroprov a prov:Activity ;\n",
-      "        rdfs:label \"\" ;\n",
-      "        prov:wasDerivedFrom <http://purl.org/np/RArXfC72LtqYAYT-_v93KOBWxHdJTUlgofCuhFN6aA7Cg#plan> .\n",
       "}\n",
       "\n",
       "\n"
@@ -352,7 +352,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "adjusted-eugene",
+   "id": "continent-nebraska",
    "metadata": {},
    "source": [
     "### Provide semantic annotations for input and output variables\n",
@@ -362,8 +362,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
-   "id": "difficult-valuable",
+   "execution_count": 15,
+   "id": "proud-fight",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -374,7 +374,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "alone-clone",
+   "id": "straight-conflict",
    "metadata": {},
    "source": [
     "If we now look at the RDF generated for the step, we will see that input parameter 'a' and the step output ('out1') both have the (additional) semantic types specified."
@@ -382,8 +382,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
-   "id": "enabling-printing",
+   "execution_count": 16,
+   "id": "promising-toronto",
    "metadata": {},
    "outputs": [
     {
@@ -392,14 +392,24 @@
      "text": [
       "Step URI = http://www.example.org/unpublished-add\n",
       "@prefix bpmn: <http://dkm.fbk.eu/index.php/BPMN2_Ontology#> .\n",
+      "@prefix dc: <http://purl.org/dc/terms/> .\n",
+      "@prefix owl: <http://www.w3.org/2002/07/owl#> .\n",
       "@prefix pplan: <http://purl.org/net/p-plan#> .\n",
       "@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n",
       "@prefix schema: <https://schema.org/> .\n",
       "\n",
-      "_:Ndeffc94ed0864503a93f312204ec3ef4 {\n",
+      "_:Ncdb1c6095888435889cc7a0150a2355e {\n",
       "    [] a bpmn:ScriptTask,\n",
       "            pplan:Step ;\n",
       "        rdfs:label \"Addition\" ;\n",
+      "        dc:description \"\"\"@is_fairstep(label='Addition', a='http://www.example.org/distance', returns='http://www.example.org/mass')\n",
+      "def add(a:float, b:float) -> float:\n",
+      "    return a + b\n",
+      "\"\"\" ;\n",
+      "        dc:language [ a schema:ComputerLanguage ;\n",
+      "                rdfs:label \"python\" ;\n",
+      "                rdfs:seeAlso <https://en.wikipedia.org/wiki/Python_(programming_language)> ;\n",
+      "                owl:versionInfo \"3.8.6.final.0\" ] ;\n",
       "        pplan:hasInputVar [ a pplan:Variable,\n",
       "                    <http://www.example.org/distance> ;\n",
       "                rdfs:label \"a\" ;\n",
@@ -410,12 +420,7 @@
       "        pplan:hasOutputVar [ a pplan:Variable,\n",
       "                    <http://www.example.org/mass> ;\n",
       "                rdfs:label \"out1\" ;\n",
-      "                rdfs:comment \"float\" ] ;\n",
-      "        schema:SoftwareSourceCode [ schema:programmingLanguage \"python 3.8.6\" ;\n",
-      "                schema:text \"\"\"@is_fairstep(label='Addition', a='http://www.example.org/distance', returns='http://www.example.org/mass')\n",
-      "def add(a:float, b:float) -> float:\n",
-      "    return a + b\n",
-      "\"\"\" ] .\n",
+      "                rdfs:comment \"float\" ] .\n",
       "}\n",
       "\n",
       "\n"
@@ -430,7 +435,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "numeric-fraction",
+   "id": "thirty-fifty",
    "metadata": {},
    "source": [
     "### Specify more than one semantic type for a parameter\n",
@@ -440,7 +445,7 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "textile-prayer",
+   "id": "angry-jason",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -453,7 +458,7 @@
   {
    "cell_type": "code",
    "execution_count": 20,
-   "id": "documented-prophet",
+   "id": "configured-chamber",
    "metadata": {},
    "outputs": [
     {
@@ -501,7 +506,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "binding-salon",
+   "id": "upset-consciousness",
    "metadata": {},
    "source": [
     "You can check the programming language that was used for writing the step:"
@@ -510,7 +515,7 @@
   {
    "cell_type": "code",
    "execution_count": 23,
-   "id": "prime-monroe",
+   "id": "photographic-hierarchy",
    "metadata": {},
    "outputs": [
     {
@@ -530,7 +535,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "statutory-waste",
+   "id": "allied-unemployment",
    "metadata": {},
    "source": [
     "## Semantic types for function producing multiple outputs\n",
@@ -540,7 +545,7 @@
   {
    "cell_type": "code",
    "execution_count": 18,
-   "id": "frequent-stanford",
+   "id": "fifth-zambia",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -553,7 +558,7 @@
   {
    "cell_type": "code",
    "execution_count": 19,
-   "id": "russian-removal",
+   "id": "deluxe-mortgage",
    "metadata": {},
    "outputs": [
     {
@@ -601,7 +606,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "atlantic-moses",
+   "id": "dimensional-mason",
    "metadata": {},
    "source": [
     "As before, you may provide a list of URIs for each output. If you do not want to provide semantic types for a particular output, simply pass None:"
@@ -609,21 +614,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "id": "approximate-cheat",
+   "execution_count": 19,
+   "id": "distinct-teacher",
    "metadata": {},
    "outputs": [],
    "source": [
     "from typing import Tuple\n",
     "@is_fairstep(label='Addition and subtraction', returns=(['http://www.example.org/distance', 'http://www.example.org/number'], None))\n",
     "def another_step(a:float, b:float) -> Tuple[float, float]:\n",
+    "    \"\"\"This step returns an addition and a subtraction of its inputs\"\"\"\n",
     "    return a + b, a - b"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "id": "spanish-duration",
+   "execution_count": 21,
+   "id": "precious-sally",
    "metadata": {},
    "outputs": [
     {
@@ -632,18 +638,25 @@
      "text": [
       "Step URI = http://www.example.org/unpublished-another_step\n",
       "@prefix bpmn: <http://dkm.fbk.eu/index.php/BPMN2_Ontology#> .\n",
-      "@prefix ns1: <http://purl.org/dc/terms/> .\n",
+      "@prefix dc: <http://purl.org/dc/terms/> .\n",
+      "@prefix owl: <http://www.w3.org/2002/07/owl#> .\n",
       "@prefix pplan: <http://purl.org/net/p-plan#> .\n",
       "@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n",
+      "@prefix schema: <https://schema.org/> .\n",
       "\n",
-      "_:Nfd09bd8a8a4c48a1b2e2e240411aad92 {\n",
+      "_:Nba7cbd6eb6c04b52bc2fc78c2d9109e2 {\n",
       "    [] a bpmn:ScriptTask,\n",
       "            pplan:Step ;\n",
       "        rdfs:label \"Addition and subtraction\" ;\n",
-      "        ns1:description \"\"\"@is_fairstep(label='Addition and subtraction', returns=(['http://www.example.org/distance', 'http://www.example.org/number'], None))\n",
+      "        dc:description \"\"\"@is_fairstep(label='Addition and subtraction', returns=(['http://www.example.org/distance', 'http://www.example.org/number'], None))\n",
       "def another_step(a:float, b:float) -> Tuple[float, float]:\n",
+      "    \\\"\\\"\\\"This step returns an addition and a subtraction of its inputs\\\"\\\"\\\"\n",
       "    return a + b, a - b\n",
       "\"\"\" ;\n",
+      "        dc:language [ a schema:ComputerLanguage ;\n",
+      "                rdfs:label \"python\" ;\n",
+      "                rdfs:seeAlso <https://en.wikipedia.org/wiki/Python_(programming_language)> ;\n",
+      "                owl:versionInfo \"3.8.6.final.0\" ] ;\n",
       "        pplan:hasInputVar [ a pplan:Variable ;\n",
       "                rdfs:label \"a\" ;\n",
       "                rdfs:comment \"float\" ],\n",
@@ -671,7 +684,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "critical-processor",
+   "id": "gentle-female",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/fairworkflows/__init__.py
+++ b/fairworkflows/__init__.py
@@ -1,3 +1,4 @@
 from ._version import __version__
+from .linguistic_system import LinguisticSystem, LINGSYS_ENGLISH, LINGSYS_PYTHON
 from .fairstep import FairStep, FairVariable, is_fairstep
 from .fairworkflow import FairWorkflow, is_fairworkflow

--- a/fairworkflows/fairstep.py
+++ b/fairworkflows/fairstep.py
@@ -1,3 +1,4 @@
+import sys
 import inspect
 import typing
 from copy import deepcopy
@@ -251,13 +252,13 @@ class FairStep(RdfWrapper):
     @property
     def programming_language(self):
         """Returns the programming language for this fairstep's code (either a string, or URI)"""
-        return self._rdf.objects(self.code_ref, namespaces.SCHEMAORG.text)
+        return self._rdf.objects(self.code_ref, namespaces.SCHEMAORG.programmingLanguage)
 
     @programming_language.setter
-    def programming_language(self, value: Union[str, rdflib.URIRef]):
-        """Sets the programming language for this fairstep's code (either a string, or URI)"""
+    def programming_language(self, value: str):
+        """Sets the programming language for this fairstep's code (takes a string)"""
         self.set_attribute(namespaces.SCHEMAORG.SoftwareSourceCode, self.code_ref, overwrite=False)
-        self._rdf.add((self.code_ref, namespaces.SCHEMAORG.programmingLanguage, value))
+        self._rdf.add((self.code_ref, namespaces.SCHEMAORG.programmingLanguage, rdflib.Literal(value)))
 
     def _get_variable(self, var_ref: Union[rdflib.term.BNode, rdflib.URIRef]) -> FairVariable:
         """Retrieve a specific FairVariable from the RDF triples."""
@@ -484,7 +485,8 @@ def is_fairstep(label: str = None, is_pplan_step: bool = True, is_manual_task: b
         # Description of step is the raw function code
         description = inspect.getdoc(func)
         code = inspect.getsource(func)
-        proglang = rdflib.URIRef('https://en.wikipedia.org/wiki/Python_(programming_language)')
+        sv = sys.version_info
+        proglangtxt = f'python {sv.major}.{sv.minor}.{sv.micro}'
         inputs = _extract_inputs_from_function(func, kwargs)
         outputs = _extract_outputs_from_function(func, kwargs)
 
@@ -495,7 +497,7 @@ def is_fairstep(label: str = None, is_pplan_step: bool = True, is_manual_task: b
                                   is_manual_task=is_manual_task,
                                   is_script_task=is_script_task,
                                   code=code,
-                                  programming_language=proglang,
+                                  programming_language=proglangtxt,
                                   inputs=inputs,
                                   outputs=outputs)
 

--- a/fairworkflows/fairstep.py
+++ b/fairworkflows/fairstep.py
@@ -291,39 +291,6 @@ class FairStep(RdfWrapper):
         for variable in variables:
             self._add_variable(variable, namespaces.PPLAN.hasOutputVar)
 
-    @property
-    def label(self):
-        """Label.
-
-        Returns the rdfs:label of this step (or a list, if more than one matching triple is found)
-        """
-        return self.get_attribute(RDFS.label)
-
-    @label.setter
-    def label(self, value):
-        """
-        Adds the given text string as an rdfs:label for this FairStep
-        object.
-        """
-        self.set_attribute(RDFS.label, rdflib.term.Literal(value))
-
-    @property
-    def description(self):
-        """Description.
-
-        Returns the dcterms:description of this step (or a list, if more than
-        one matching triple is found)
-        """
-        return self.get_attribute(DCTERMS.description)
-
-    @description.setter
-    def description(self, value):
-        """
-        Adds the given text string as a dcterms:description for this FairStep
-        object.
-        """
-        self.set_attribute(DCTERMS.description, rdflib.term.Literal(value))
-
     def validate(self, shacl=False):
         """Validate step.
 

--- a/fairworkflows/fairstep.py
+++ b/fairworkflows/fairstep.py
@@ -90,7 +90,7 @@ class FairStep(RdfWrapper):
                  language: LinguisticSystem = LINGSYS_ENGLISH,
                  inputs: List[FairVariable] = None,
                  outputs: List[FairVariable] = None, derived_from=None):
-        super().__init__(uri=uri, ref_name='step', derived_from=derived_from)
+        super().__init__(uri=uri, ref_name='step', derived_from=derived_from, language=language)
 
         if label is not None:
             self.label = label
@@ -104,8 +104,6 @@ class FairStep(RdfWrapper):
             self.is_manual_task = is_manual_task
         if is_script_task is not None:
             self.is_script_task = is_script_task
-        if language is not None:
-            self.language = language
         if inputs is not None:
             self.inputs = inputs
         if outputs is not None:

--- a/fairworkflows/fairstep.py
+++ b/fairworkflows/fairstep.py
@@ -1,5 +1,6 @@
 import sys
 import inspect
+import warnings
 import typing
 from copy import deepcopy
 from typing import Callable, get_type_hints, List, Union
@@ -87,7 +88,7 @@ class FairStep(RdfWrapper):
     def __init__(self, label: str = None, description: str = None, uri=None,
                  is_pplan_step: bool = True, is_manual_task: bool = None,
                  is_script_task: bool = None, code: str = None,
-                 programming_language: Union[str, rdflib.URIRef] = None,
+                 programming_language: str = None,
                  inputs: List[FairVariable] = None,
                  outputs: List[FairVariable] = None, derived_from=None):
         super().__init__(uri=uri, ref_name='step', derived_from=derived_from)
@@ -241,7 +242,14 @@ class FairStep(RdfWrapper):
     @property
     def code(self):
         """Returns the code text associated with this FairStep, or None if there isn't any."""
-        return self._rdf.objects(self.code_ref, namespaces.SCHEMAORG.text)
+        stepcode = list(self._rdf.objects(self.code_ref, namespaces.SCHEMAORG.text))
+        if len(stepcode) == 0:
+            return None
+        if len(stepcode) > 1:
+            warnings.warn('There is more than one code text associated with '
+                          'this FairStep in its RDF description: {stepcode}. '
+                          'Returning only the first in list.')
+        return str(stepcode[0])
 
     @code.setter
     def code(self, value: str):
@@ -252,7 +260,14 @@ class FairStep(RdfWrapper):
     @property
     def programming_language(self):
         """Returns the programming language for this fairstep's code (either a string, or URI)"""
-        return self._rdf.objects(self.code_ref, namespaces.SCHEMAORG.programmingLanguage)
+        proglang = list(self._rdf.objects(self.code_ref, namespaces.SCHEMAORG.programmingLanguage))
+        if len(proglang) == 0:
+            return None
+        if len(proglang) > 1:
+            warnings.warn('There is more than one programming language associated with the code '
+                          'for this FairStep in its RDF description: {proglang}. Returning only '
+                          'the first in list.')
+        return str(proglang[0])
 
     @programming_language.setter
     def programming_language(self, value: str):

--- a/fairworkflows/fairstep.py
+++ b/fairworkflows/fairstep.py
@@ -92,11 +92,6 @@ class FairStep(RdfWrapper):
                  outputs: List[FairVariable] = None, derived_from=None):
         super().__init__(uri=uri, ref_name='step', derived_from=derived_from)
 
-        # A blank node to which triples about the linguistic
-        # system for this FAIR object can be added
-        self.lingsys_ref = rdflib.BNode('LinguisticSystem')
-        self._rdf.add((self.self_ref, DCTERMS.language, self.lingsys_ref))
-
         if label is not None:
             self.label = label
         if description is not None:
@@ -237,26 +232,6 @@ class FairStep(RdfWrapper):
             self.is_manual_task = False  # manual and script are mutually exclusive
         else:
             self.remove_attribute(RDF.type, object=namespaces.BPMN.ScriptTask)
-
-    @property
-    def language(self):
-        """Returns the language for this fairstep's description (could be code).
-           Returns a LinguisticSystem object.
-        """
-        lingsys_rdf = rdflib.Graph()
-        for t in self._rdf.triples((self.lingsys_ref, None, None)):
-            lingsys_rdf.add(t)
-        return LinguisticSystem.from_rdf(lingsys_rdf)
-
-    @language.setter
-    def language(self, value: LinguisticSystem):
-        """Sets the language for this fairstep's code (takes a LinguisticSystem).
-           Removes the existing linguistic system triples from the RDF decription
-           and replaces them with the new linguistic system."""
-        lingsys_triples = list(self._rdf.triples( (self.lingsys_ref, None, None) ))
-        if len(lingsys_triples) > 0:
-            self._rdf.remove(lingsys_triples)
-        self._rdf += value.generate_rdf(self.lingsys_ref)
 
     def _get_variable(self, var_ref: Union[rdflib.term.BNode, rdflib.URIRef]) -> FairVariable:
         """Retrieve a specific FairVariable from the RDF triples."""

--- a/fairworkflows/fairworkflow.py
+++ b/fairworkflows/fairworkflow.py
@@ -282,35 +282,6 @@ class FairWorkflow(RdfWrapper):
         """
         return self._steps[uri]
 
-    @property
-    def label(self):
-        """Label.
-
-        Returns the rdfs:label of this workflow (or a list, if more than one matching triple is found)
-        """
-        return self.get_attribute(RDFS.label)
-
-    @label.setter
-    def label(self, value):
-        """
-        Adds the given text string as an rdfs:label for this FairWorkflow
-        object.
-        """
-        self.set_attribute(RDFS.label, rdflib.term.Literal(value))
-
-    @property
-    def description(self):
-        """
-        Description of the workflow. This is the dcterms:description found in
-        the rdf for this workflow (or a list if more than one matching triple
-        found)
-        """
-        return self.get_attribute(DCTERMS.description)
-
-    @description.setter
-    def description(self, value):
-        self.set_attribute(DCTERMS.description, rdflib.term.Literal(value))
-
     def validate(self, shacl=False):
         """Validate workflow.
 

--- a/fairworkflows/fairworkflow.py
+++ b/fairworkflows/fairworkflow.py
@@ -34,15 +34,13 @@ class FairWorkflow(RdfWrapper):
     def __init__(self, description: str = None, label: str = None, uri=None,
                  language: LinguisticSystem = None,
                  is_pplan_plan: bool = True, first_step: FairStep = None, derived_from=None):
-        super().__init__(uri=uri, ref_name='plan', derived_from=derived_from)
+        super().__init__(uri=uri, ref_name='plan', derived_from=derived_from, language=language)
         self._is_published = False
         self.is_pplan_plan = is_pplan_plan
         if description is not None:
             self.description = description
         if label is not None:
             self.label = label
-        if language is not None:
-            self.language = language
         self._steps = {}
         self._last_step_added = None
         if first_step is not None:

--- a/fairworkflows/fairworkflow.py
+++ b/fairworkflows/fairworkflow.py
@@ -16,7 +16,7 @@ from rdflib import RDF, RDFS, DCTERMS
 from rdflib.tools.rdf2dot import rdf2dot
 from requests import HTTPError
 
-from fairworkflows import namespaces
+from fairworkflows import namespaces, LinguisticSystem, LINGSYS_ENGLISH, LINGSYS_PYTHON
 from fairworkflows.fairstep import FairStep
 from fairworkflows.rdf_wrapper import RdfWrapper
 
@@ -32,6 +32,7 @@ class FairWorkflow(RdfWrapper):
     """
 
     def __init__(self, description: str = None, label: str = None, uri=None,
+                 language: LinguisticSystem = None,
                  is_pplan_plan: bool = True, first_step: FairStep = None, derived_from=None):
         super().__init__(uri=uri, ref_name='plan', derived_from=derived_from)
         self._is_published = False
@@ -40,6 +41,8 @@ class FairWorkflow(RdfWrapper):
             self.description = description
         if label is not None:
             self.label = label
+        if language is not None:
+            self.language = language
         self._steps = {}
         self._last_step_added = None
         if first_step is not None:
@@ -87,7 +90,8 @@ class FairWorkflow(RdfWrapper):
     @classmethod
     def from_noodles_promise(cls, noodles_promise, description: str = None, label: str = None,
                  is_pplan_plan: bool = True, derived_from=None):
-        self = cls(description=description, label=label, is_pplan_plan=is_pplan_plan, derived_from=derived_from)
+        self = cls(description=description, label=label, is_pplan_plan=is_pplan_plan,
+                   derived_from=derived_from, language=LINGSYS_PYTHON)
         self.noodles_promise = noodles_promise
 
         workflow = noodles.get_workflow(self.noodles_promise)

--- a/fairworkflows/linguistic_system.py
+++ b/fairworkflows/linguistic_system.py
@@ -16,8 +16,8 @@ class LinguisticSystem:
     def from_rdf(cls, rdf):
         lstype = _check_unique(list(rdf.objects(None, RDF.type)))
         label = _check_unique(list(rdf.objects(None, RDFS.label)))
-        see_also = _check_unique(list(rdf.objects(None, RDFS.see_also)))
-        version_info = _check_unique(list(rdf.objects(None, OWL.version_info)))
+        see_also = _check_unique(list(rdf.objects(None, RDFS.seeAlso)))
+        version_info = _check_unique(list(rdf.objects(None, OWL.versionInfo)))
         return cls(lstype = lstype,
                    label=label,
                    see_also=see_also,
@@ -51,10 +51,10 @@ def _check_unique(l: List):
 
 LINGSYS_ENGLISH = LinguisticSystem(lstype=DC.LinguisticSystem,
                                    label='en',
-                                   seeAlso="http://www.datypic.com/sc/xsd/t-xsd_language.html")
+                                   see_also="http://www.datypic.com/sc/xsd/t-xsd_language.html")
 
 LINGSYS_PYTHON = LinguisticSystem(lstype=SCHEMAORG.ComputerLanguage,
                                   label='python',
-                                  versionInfo='.'.join([str(v) for v in sys.version_info]),
-                                  seeAlso="https://en.wikipedia.org/wiki/Python_(programming_language)")
+                                  version_info='.'.join([str(v) for v in sys.version_info]),
+                                  see_also="https://en.wikipedia.org/wiki/Python_(programming_language)")
 

--- a/fairworkflows/linguistic_system.py
+++ b/fairworkflows/linguistic_system.py
@@ -1,0 +1,52 @@
+import sys
+import warnings
+from typing import List
+import rdflib
+from rdflib import DC, RDF, RDFS, OWL
+from .namespaces import SCHEMAORG
+
+class LinguisticSystem:
+    def __init__(self, lstype: rdflib.URIRef = None, label: str = None, seeAlso: rdflib.URIRef = None, versionInfo: str = None):
+        self.lstype = rdflib.URIRef(lstype)
+        self.label = rdflib.Literal(label)
+        self.seeAlso = rdflib.URIRef(seeAlso)
+        self.versionInfo = rdflib.Literal(versionInfo)
+
+    @classmethod
+    def from_rdf(cls, rdf):
+        lstype = _check_unique(list(rdf.objects(None, RDF.type)))
+        label = _check_unique(list(rdf.objects(None, RDFS.label)))
+        seeAlso = _check_unique(list(rdf.objects(None, RDFS.seeAlso)))
+        versionInfo = _check_unique(list(rdf.objects(None, OWL.versionInfo)))
+        return cls(lstype = lstype,
+                   label=label,
+                   seeAlso=seeAlso,
+                   versionInfo=versionInfo)
+
+    def generate_rdf(self, ref: rdflib.BNode):
+        rdf = rdflib.Graph()
+        if self.lstype:
+            rdf.add( (ref, RDF.type, self.lstype) )
+        if self.label:
+            rdf.add( (ref, RDFS.label, self.label) )
+        if self.seeAlso:
+            rdf.add( (ref, RDFS.seeAlso, self.seeAlso) )
+        if self.versionInfo:
+            rdf.add( (ref, OWL.versionInfo, self.versionInfo) )
+        return rdf
+
+LINGSYS_ENGLISH = LinguisticSystem(lstype=DC.LinguisticSystem,
+                                   label='en',
+                                   seeAlso="http://www.datypic.com/sc/xsd/t-xsd_language.html")
+
+LINGSYS_PYTHON = LinguisticSystem(lstype=SCHEMAORG.ComputerLanguage,
+                                  label='python',
+                                  versionInfo='.'.join([str(v) for v in sys.version_info]),
+                                  seeAlso="https://en.wikipedia.org/wiki/Python_(programming_language)")
+
+def _check_unique(l: List):
+    if len(l) == 0:
+        return None
+    if len(l) > 1:
+        warnings.warn(f'Only one triple expected, but found {len(l)}: {l}')
+    return l[0]

--- a/fairworkflows/linguistic_system.py
+++ b/fairworkflows/linguistic_system.py
@@ -6,22 +6,22 @@ from rdflib import DC, RDF, RDFS, OWL
 from .namespaces import SCHEMAORG
 
 class LinguisticSystem:
-    def __init__(self, lstype: rdflib.URIRef = None, label: str = None, seeAlso: rdflib.URIRef = None, versionInfo: str = None):
+    def __init__(self, lstype: rdflib.URIRef = None, label: str = None, see_also: rdflib.URIRef = None, version_info: str = None):
         self.lstype = rdflib.URIRef(lstype)
         self.label = rdflib.Literal(label)
-        self.seeAlso = rdflib.URIRef(seeAlso)
-        self.versionInfo = rdflib.Literal(versionInfo)
+        self.see_also = rdflib.URIRef(see_also)
+        self.version_info = rdflib.Literal(version_info)
 
     @classmethod
     def from_rdf(cls, rdf):
         lstype = _check_unique(list(rdf.objects(None, RDF.type)))
         label = _check_unique(list(rdf.objects(None, RDFS.label)))
-        seeAlso = _check_unique(list(rdf.objects(None, RDFS.seeAlso)))
-        versionInfo = _check_unique(list(rdf.objects(None, OWL.versionInfo)))
+        see_also = _check_unique(list(rdf.objects(None, RDFS.see_also)))
+        version_info = _check_unique(list(rdf.objects(None, OWL.version_info)))
         return cls(lstype = lstype,
                    label=label,
-                   seeAlso=seeAlso,
-                   versionInfo=versionInfo)
+                   see_also=see_also,
+                   version_info=version_info)
 
     def generate_rdf(self, ref: rdflib.BNode):
         rdf = rdflib.Graph()
@@ -29,15 +29,15 @@ class LinguisticSystem:
             rdf.add( (ref, RDF.type, self.lstype) )
         if self.label:
             rdf.add( (ref, RDFS.label, self.label) )
-        if self.seeAlso:
-            rdf.add( (ref, RDFS.seeAlso, self.seeAlso) )
-        if self.versionInfo:
-            rdf.add( (ref, OWL.versionInfo, self.versionInfo) )
+        if self.see_also:
+            rdf.add( (ref, RDFS.seeAlso, self.see_also) )
+        if self.version_info:
+            rdf.add( (ref, OWL.versionInfo, self.version_info) )
         return rdf
 
     def __str__(self):
         return (f'LinguisticSystem with type={self.lstype}, label={self.label}, '
-                f'seeAlso={self.seeAlso}, versionInfo={self.versionInfo}')
+                f'seeAlso={self.see_also}, versionInfo={self.version_info}')
 
 
 def _check_unique(l: List):

--- a/fairworkflows/linguistic_system.py
+++ b/fairworkflows/linguistic_system.py
@@ -35,6 +35,20 @@ class LinguisticSystem:
             rdf.add( (ref, OWL.versionInfo, self.versionInfo) )
         return rdf
 
+    def __str__(self):
+        return (f'LinguisticSystem with type={self.lstype}, label={self.label}, '
+                f'seeAlso={self.seeAlso}, versionInfo={self.versionInfo}')
+
+
+def _check_unique(l: List):
+    if len(l) == 0:
+        return None
+    if len(l) > 1:
+        warnings.warn(f'Only one triple expected, but found {len(l)}: {l}')
+    return l[0]
+
+
+
 LINGSYS_ENGLISH = LinguisticSystem(lstype=DC.LinguisticSystem,
                                    label='en',
                                    seeAlso="http://www.datypic.com/sc/xsd/t-xsd_language.html")
@@ -44,9 +58,3 @@ LINGSYS_PYTHON = LinguisticSystem(lstype=SCHEMAORG.ComputerLanguage,
                                   versionInfo='.'.join([str(v) for v in sys.version_info]),
                                   seeAlso="https://en.wikipedia.org/wiki/Python_(programming_language)")
 
-def _check_unique(l: List):
-    if len(l) == 0:
-        return None
-    if len(l) > 1:
-        warnings.warn(f'Only one triple expected, but found {len(l)}: {l}')
-    return l[0]

--- a/fairworkflows/namespaces.py
+++ b/fairworkflows/namespaces.py
@@ -5,6 +5,7 @@ PPLAN = rdflib.Namespace("http://purl.org/net/p-plan#")
 DUL = rdflib.Namespace("http://www.ontologydesignpatterns.org/ont/dul/DUL.owl#")
 BPMN = rdflib.Namespace("http://dkm.fbk.eu/index.php/BPMN2_Ontology#")
 PWO = rdflib.Namespace("http://purl.org/spar/pwo/")
+SCHEMAORG = rdflib.Namespace("https://schema.org/")
 
 """
 Namespace for

--- a/fairworkflows/rdf_wrapper.py
+++ b/fairworkflows/rdf_wrapper.py
@@ -14,19 +14,24 @@ from fairworkflows.config import PACKAGE_DIR
 PLEX_SHAPES_SHACL_FILEPATH = str(PACKAGE_DIR / 'resources' / 'plex-shapes.ttl')
 
 class RdfWrapper:
-    def __init__(self, uri, ref_name='fairobject', derived_from: List[str] = None):
+    def __init__(self, uri, ref_name='fairobject', derived_from: List[str] = None,
+                 language: LinguisticSystem = None ):
         self._rdf = rdflib.Graph()
         self._uri = str(uri)
         self.self_ref = rdflib.term.BNode(ref_name)
         self._is_modified = False
         self._is_published = False
         self.derived_from = derived_from
+
         self._bind_namespaces()
 
         # A blank node to which triples about the linguistic
         # system for this FAIR object can be added
         self.lingsys_ref = rdflib.BNode('LinguisticSystem')
         self._rdf.add((self.self_ref, DCTERMS.language, self.lingsys_ref))
+
+        if language is not None:
+            self.language = language
 
     def _bind_namespaces(self):
         """Bind namespaces used often in fair step and fair workflow.

--- a/fairworkflows/rdf_wrapper.py
+++ b/fairworkflows/rdf_wrapper.py
@@ -32,6 +32,7 @@ class RdfWrapper:
         self.rdf.bind("dul", namespaces.DUL)
         self.rdf.bind("bpmn", namespaces.BPMN)
         self.rdf.bind("pwo", namespaces.PWO)
+        self.rdf.bind("schema", namespaces.SCHEMAORG)
 
     @property
     def rdf(self) -> rdflib.Graph:

--- a/fairworkflows/rdf_wrapper.py
+++ b/fairworkflows/rdf_wrapper.py
@@ -4,6 +4,7 @@ from urllib.parse import urldefrag
 
 import pyshacl
 import rdflib
+from rdflib import DCTERMS, OWL
 
 from nanopub import Publication, NanopubClient
 
@@ -33,6 +34,8 @@ class RdfWrapper:
         self.rdf.bind("bpmn", namespaces.BPMN)
         self.rdf.bind("pwo", namespaces.PWO)
         self.rdf.bind("schema", namespaces.SCHEMAORG)
+        self.rdf.bind("dc", DCTERMS)
+        self.rdf.bind("owl", OWL)
 
     @property
     def rdf(self) -> rdflib.Graph:

--- a/fairworkflows/rdf_wrapper.py
+++ b/fairworkflows/rdf_wrapper.py
@@ -4,13 +4,13 @@ from urllib.parse import urldefrag
 
 import pyshacl
 import rdflib
+
 from nanopub import Publication, NanopubClient
 
 from fairworkflows import namespaces
 from fairworkflows.config import PACKAGE_DIR
 
 PLEX_SHAPES_SHACL_FILEPATH = str(PACKAGE_DIR / 'resources' / 'plex-shapes.ttl')
-
 
 class RdfWrapper:
     def __init__(self, uri, ref_name='fairobject', derived_from: List[str] = None):

--- a/fairworkflows/rdf_wrapper.py
+++ b/fairworkflows/rdf_wrapper.py
@@ -4,8 +4,7 @@ from urllib.parse import urldefrag
 
 import pyshacl
 import rdflib
-from rdflib import DCTERMS, OWL
-
+from rdflib import RDF, RDFS, DCTERMS, OWL
 from nanopub import Publication, NanopubClient
 
 from fairworkflows import namespaces, LinguisticSystem
@@ -126,8 +125,39 @@ class RdfWrapper:
         self._rdf.remove((self.self_ref, predicate, object))
 
     @property
+    def label(self):
+        """Label.
+
+        Returns the rdfs:label of this Fair object (or a list, if more than one matching triple is found)
+        """
+        return self.get_attribute(RDFS.label)
+
+    @label.setter
+    def label(self, value):
+        """
+        Adds the given text string as an rdfs:label for this Fair object.
+        """
+        self.set_attribute(RDFS.label, rdflib.term.Literal(value))
+
+    @property
+    def description(self):
+        """Description.
+
+        Returns the dcterms:description of this Fair object (or a list, if more than
+        one matching triple is found)
+        """
+        return self.get_attribute(DCTERMS.description)
+
+    @description.setter
+    def description(self, value):
+        """
+        Adds the given text string as a dcterms:description for this Fair object.
+        """
+        self.set_attribute(DCTERMS.description, rdflib.term.Literal(value))
+
+    @property
     def language(self):
-        """Returns the language for this fairstep's description (could be code).
+        """Returns the language for this fair objects's description (could be code).
            Returns a LinguisticSystem object.
         """
         lingsys_rdf = rdflib.Graph()
@@ -137,7 +167,7 @@ class RdfWrapper:
 
     @language.setter
     def language(self, value: LinguisticSystem):
-        """Sets the language for this fairstep's code (takes a LinguisticSystem).
+        """Sets the language for this fair object's code (takes a LinguisticSystem).
            Removes the existing linguistic system triples from the RDF decription
            and replaces them with the new linguistic system."""
         lingsys_triples = list(self._rdf.triples( (self.lingsys_ref, None, None) ))

--- a/tests/test_fairstep.py
+++ b/tests/test_fairstep.py
@@ -10,7 +10,7 @@ from conftest import skip_if_nanopub_server_unavailable, read_rdf_test_resource
 from fairworkflows import FairStep, namespaces, FairVariable, is_fairworkflow
 from fairworkflows.fairstep import _extract_outputs_from_function, is_fairstep
 from fairworkflows.rdf_wrapper import replace_in_rdf
-
+from fairworkflows import LinguisticSystem
 
 def test_construct_fair_variable_get_name_from_uri():
     variable = FairVariable(name=None, uri='http:example.org#input1', computational_type='int')
@@ -274,11 +274,9 @@ def test_decorator_semantic_types():
     else:
         raise
 
-    assert test_step._fairstep.programming_language is not None
-    assert isinstance(test_step._fairstep.programming_language, str)
-    assert 'python' in test_step._fairstep.programming_language
-    assert test_step._fairstep.code is not None
-    assert isinstance(test_step._fairstep.code, str)
+    assert test_step._fairstep.language is not None
+    assert isinstance(test_step._fairstep.language, LinguisticSystem)
+    assert 'python' in test_step._fairstep.language.label
 
 
 def test_decorator_semantic_types_multiple_outputs():

--- a/tests/test_fairstep.py
+++ b/tests/test_fairstep.py
@@ -1,3 +1,4 @@
+import sys
 from typing import Tuple
 from unittest.mock import patch
 
@@ -272,6 +273,13 @@ def test_decorator_semantic_types():
             break
     else:
         raise
+
+    assert test_step._fairstep.programming_language is not None
+    assert isinstance(test_step._fairstep.programming_language, str)
+    assert 'python' in test_step._fairstep.programming_language
+    assert test_step._fairstep.code is not None
+    assert isinstance(test_step._fairstep.code, str)
+
 
 def test_decorator_semantic_types_multiple_outputs():
     output_tuple = ('http://www.example.org/walrus', 'http://www.example.org/krill')

--- a/tests/test_fairstep.py
+++ b/tests/test_fairstep.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 import pytest
 import rdflib
+from rdflib import DCTERMS, OWL, RDF
 from nanopub import Publication
 
 from conftest import skip_if_nanopub_server_unavailable, read_rdf_test_resource
@@ -276,6 +277,9 @@ def test_decorator_semantic_types():
 
     assert test_step._fairstep.language is not None
     assert isinstance(test_step._fairstep.language, LinguisticSystem)
+    assert (None, RDF.type, namespaces.SCHEMAORG.ComputerLanguage) in test_step._fairstep._rdf
+    assert (None, DCTERMS.language, None) in test_step._fairstep._rdf
+    assert (None, OWL.versionInfo, None) in test_step._fairstep._rdf
     assert 'python' in test_step._fairstep.language.label
 
 


### PR DESCRIPTION
Fixes #164 

Note that the source code no longer appears in the `dcterms:description' - that is now the docstring of the function.
There is now a `#code` fragment that is a `schema:SoftwareSourceCode` which has a `schema:programmingLanguage` (e.g. 'python 3.6.0') and a `schema:text` which points to the actual raw source code.

I am attempting to santise the RDF generated for these code fragments, by at the very least putting them in a dedicated code section. In future, that could simply be a URL to a code location (repository etc) and the language could be something else entirely.

For now, there remains an issue of doing this for the ```FairWorkflow``` object, which itself has raw source code that describes its 'workflow'. In accordance with the original plex diagram, I would like to have that `p-plan:Plan` be `dul:describedBy` a `p-plan:Step`, and that way the step already handles all of this source code RDF stuff. An additional benefit is that it also solves any semantic typing issues discussed in #161 by sidestepping it altogether.