### PR TITLE
Fix missing steps bug in is-fairworkflows decorator

### DIFF
--- a/fairworkflows/fairworkflow.py
+++ b/fairworkflows/fairworkflow.py
@@ -414,7 +414,7 @@ class FairWorkflow(RdfWrapper):
 
     def _replace_input_arguments(self, promise: noodles.interface.PromisedObject, args, kwargs):
         """
-        Replace the input arguments of the step_level_promise so we can run the workflow with the right
+        Replace the input arguments of the promise so we can run the workflow with the right
         inputs. This goes into the guts of noodles, doing something noodles was not intended to be
         used for.
         TODO: find a better solution for this
@@ -543,7 +543,7 @@ def is_fairworkflow(label: str = None, is_pplan_plan: bool = True):
         workflow_level_promise = scheduled_workflow(*empty_args)
         step_level_promise = func(*empty_args)
         if not isinstance(step_level_promise, PromisedObject):
-            raise TypeError("The workflow does not return a 'step_level_promise'. Did you use the "
+            raise TypeError("The workflow does not return a 'promise'. Did you use the "
                             "is_fairstep decorator on all the steps?")
 
         # Description of workflow is the raw function code

--- a/fairworkflows/fairworkflow.py
+++ b/fairworkflows/fairworkflow.py
@@ -85,23 +85,28 @@ class FairWorkflow(RdfWrapper):
                              'use is_fairworkflow decorator to mark it.')
 
     @classmethod
-    def from_noodles_promise(cls, noodles_promise, description: str = None, label: str = None,
-                 is_pplan_plan: bool = True, derived_from=None):
+    def from_noodles_promise(cls, workflow_level_promise, step_level_promise, description: str = None, label: str =
+                             None, is_pplan_plan: bool = True, derived_from=None):
+        """
+
+        Args:
+            workflow_level_promise: Noodles workflow_level_promise at the workflow function level.
+                This excludes the individual steps, but we need it to do proper execution.
+            step_level_promise: Promise at the steps level. This includes the individual steps as
+                nodes but does not bind them together. We use this to extract step information from
+                it.
+        """
         self = cls(description=description, label=label, is_pplan_plan=is_pplan_plan, derived_from=derived_from)
-        self.noodles_promise = noodles_promise
+        self.workflow_level_promise = workflow_level_promise
 
-        workflow = noodles.get_workflow(self.noodles_promise)
+        workflow = noodles.get_workflow(step_level_promise)
 
-        # Exclude the root, because that is the workflow definition itself and not a step
-        steps_dict = {i: n.foo._fairstep for i, n in workflow.nodes.items() if i != workflow.root}
+        steps_dict = {i: n.foo._fairstep for i, n in workflow.nodes.items()}
 
         for i, step in steps_dict.items():
             self._add_step(step)
 
         for i in workflow.links:
-            # Exclude the root, because that is the workflow definition itself and not a step
-            if i == workflow.root:
-                continue
             current_step = steps_dict[i]
             from_uri = rdflib.URIRef(steps_dict[i].uri + '#' + current_step.outputs[0].name)
             for j in workflow.links[i]:
@@ -364,10 +369,10 @@ class FairWorkflow(RdfWrapper):
         if full_rdf:
             return self.display_full_rdf()
         else:
-            if not hasattr(self, 'noodles_promise'):
-                raise ValueError('Cannot display workflow as no noodles promise has been constructed.')
+            if not hasattr(self, 'workflow_level_promise'):
+                raise ValueError('Cannot display workflow as no noodles step_level_promise has been constructed.')
             import noodles.tutorial
-            noodles.tutorial.display_workflows(prefix='control', workflow=self.noodles_promise)
+            noodles.tutorial.display_workflows(prefix='control', workflow=self.workflow_level_promise)
 
     def display_full_rdf(self):
         graphviz = self._import_graphviz()
@@ -388,8 +393,8 @@ class FairWorkflow(RdfWrapper):
         workflow and retroprov is the retrospective provenance logged during execution.
         """
 
-        if not hasattr(self, 'noodles_promise'):
-            raise ValueError('Cannot execute workflow as no noodles promise has been constructed.')
+        if not hasattr(self, 'workflow_level_promise'):
+            raise ValueError('Cannot execute workflow as no noodles step_level_promise has been constructed.')
 
         log = io.StringIO()
         log_handler = logging.StreamHandler(log)
@@ -399,8 +404,8 @@ class FairWorkflow(RdfWrapper):
         logger = logging.getLogger('noodles')
         logger.setLevel(logging.INFO)
         logger.handlers = [log_handler]
-        self.noodles_promise = self._replace_input_arguments(self.noodles_promise, args, kwargs)
-        result = noodles.run_single(self.noodles_promise)
+        self.workflow_level_promise = self._replace_input_arguments(self.workflow_level_promise, args, kwargs)
+        result = noodles.run_single(self.workflow_level_promise)
 
         # Generate the retrospective provenance as a (nano-) Publication object
         retroprov = self._generate_retrospective_prov_publication(log.getvalue())
@@ -409,7 +414,7 @@ class FairWorkflow(RdfWrapper):
 
     def _replace_input_arguments(self, promise: noodles.interface.PromisedObject, args, kwargs):
         """
-        Replace the input arguments of the promise so we can run the workflow with the right
+        Replace the input arguments of the step_level_promise so we can run the workflow with the right
         inputs. This goes into the guts of noodles, doing something noodles was not intended to be
         used for.
         TODO: find a better solution for this
@@ -535,15 +540,16 @@ def is_fairworkflow(label: str = None, is_pplan_plan: bool = True):
         scheduled_workflow = noodles.schedule(func)
         num_params = len(inspect.signature(func).parameters)
         empty_args = ([inspect.Parameter.empty()] * num_params)
-        promise = scheduled_workflow(*empty_args)
-        if not isinstance(func(*empty_args), PromisedObject):
-            raise TypeError("The workflow does not return a 'promise'. Did you use the "
+        workflow_level_promise = scheduled_workflow(*empty_args)
+        step_level_promise = func(*empty_args)
+        if not isinstance(step_level_promise, PromisedObject):
+            raise TypeError("The workflow does not return a 'step_level_promise'. Did you use the "
                             "is_fairstep decorator on all the steps?")
 
         # Description of workflow is the raw function code
         description = inspect.getsource(func)
-        promise._fairworkflow = FairWorkflow.from_noodles_promise(
-            promise, description=description, label=label,
+        workflow_level_promise._fairworkflow = FairWorkflow.from_noodles_promise(
+            workflow_level_promise, step_level_promise, description=description, label=label,
             is_pplan_plan=is_pplan_plan, derived_from=None)
-        return promise
+        return workflow_level_promise
     return _modify_function

--- a/tests/test_fairworkflow.py
+++ b/tests/test_fairworkflow.py
@@ -395,4 +395,4 @@ class TestFairWorkflow:
                 A simple workflow
                 """
                 return return_value(in1)
-        assert "The workflow does not return a 'step_level_promise'" in str(e.value)
+        assert "The workflow does not return a 'promise'" in str(e.value)

--- a/tests/test_fairworkflow.py
+++ b/tests/test_fairworkflow.py
@@ -347,6 +347,7 @@ class TestFairWorkflow:
         fw = FairWorkflow.from_function(my_workflow)
 
         assert isinstance(fw, FairWorkflow)
+        assert len(fw._steps) == 4
 
         result, prov = fw.execute(1, 4, 3)
         assert result == -66
@@ -394,4 +395,4 @@ class TestFairWorkflow:
                 A simple workflow
                 """
                 return return_value(in1)
-        assert "The workflow does not return a 'promise'" in str(e.value)
+        assert "The workflow does not return a 'step_level_promise'" in str(e.value)


### PR DESCRIPTION
See the addition to the test, the FairWorkflow object resulting from specifying the workflow with `is_fairworkflow` decorator did not have any steps. This is because apparently the PromisedObject created out of the scheduled workflow does not hold information about the individual steps. See here my horrible solution. Since this noodles execution is super horrible code anyway I don't think we should spend a lot of time in making this nicer at this point.

Fixes #175 