### PR TITLE
Fix retrospective logging

### DIFF
--- a/fairworkflows/config.py
+++ b/fairworkflows/config.py
@@ -1,3 +1,4 @@
+import logging
 from pathlib import Path
 
 PACKAGE_DIR = Path(__file__).parent.absolute()
@@ -11,3 +12,5 @@ PLEX_DIR = 'plex'
 
 DUMMY_FAIRWORKFLOWS_URI = 'http://fairworkflows.org'
 IS_FAIRSTEP_RETURN_VALUE_PARAMETER_NAME='returns'
+
+LOGGER = logging.getLogger('fairworkflows')

--- a/fairworkflows/fairstep.py
+++ b/fairworkflows/fairstep.py
@@ -1,3 +1,4 @@
+import functools
 import sys
 import inspect
 import typing
@@ -437,6 +438,7 @@ def is_fairstep(label: str = None, is_pplan_step: bool = True, is_manual_task: b
                             inputs=inputs,
                             outputs=outputs)
 
+        @functools.wraps
         def _add_logging(func):
             def _wrapper(*func_args, **func_kwargs):
                 LOGGER.info(f'Running step: {func.__name__}')

--- a/fairworkflows/fairstep.py
+++ b/fairworkflows/fairstep.py
@@ -464,7 +464,7 @@ def is_fairstep(label: str = None, is_pplan_step: bool = True, is_manual_task: b
                                   inputs=inputs,
                                   outputs=outputs)
 
-        return noodles.schedule(func)
+        return noodles.schedule(func, display=f'Running step: {func.__name__}')
 
     return _modify_function
 

--- a/fairworkflows/fairstep.py
+++ b/fairworkflows/fairstep.py
@@ -9,8 +9,10 @@ import rdflib
 from rdflib import RDF, RDFS, DCTERMS
 
 from fairworkflows import namespaces
-from fairworkflows.config import DUMMY_FAIRWORKFLOWS_URI, IS_FAIRSTEP_RETURN_VALUE_PARAMETER_NAME
+from fairworkflows.config import DUMMY_FAIRWORKFLOWS_URI, IS_FAIRSTEP_RETURN_VALUE_PARAMETER_NAME, \
+    LOGGER
 from fairworkflows.rdf_wrapper import RdfWrapper, replace_in_rdf
+
 
 class FairVariable:
     """Represents a variable.
@@ -464,7 +466,13 @@ def is_fairstep(label: str = None, is_pplan_step: bool = True, is_manual_task: b
                                   inputs=inputs,
                                   outputs=outputs)
 
-        return noodles.schedule(func, display=f'Running step: {func.__name__}')
+        def _add_logging(func):
+            def _wrapper(*func_args, **func_kwargs):
+                LOGGER.info(f'Running step: {func.__name__}')
+                return func(*func_args, **func_kwargs)
+            return _wrapper
+
+        return noodles.schedule(_add_logging(func))
 
     return _modify_function
 

--- a/fairworkflows/fairstep.py
+++ b/fairworkflows/fairstep.py
@@ -456,23 +456,23 @@ def is_fairstep(label: str = None, is_pplan_step: bool = True, is_manual_task: b
         inputs = _extract_inputs_from_function(func, kwargs)
         outputs = _extract_outputs_from_function(func, kwargs)
 
-
-        func._fairstep = FairStep(uri='http://www.example.org/unpublished-'+func.__name__,
-                                  label=label,
-                                  description=description,
-                                  is_pplan_step=is_pplan_step,
-                                  is_manual_task=is_manual_task,
-                                  is_script_task=is_script_task,
-                                  inputs=inputs,
-                                  outputs=outputs)
+        fairstep = FairStep(uri='http://www.example.org/unpublished-'+func.__name__,
+                            label=label,
+                            description=description,
+                            is_pplan_step=is_pplan_step,
+                            is_manual_task=is_manual_task,
+                            is_script_task=is_script_task,
+                            inputs=inputs,
+                            outputs=outputs)
 
         def _add_logging(func):
             def _wrapper(*func_args, **func_kwargs):
                 LOGGER.info(f'Running step: {func.__name__}')
                 return func(*func_args, **func_kwargs)
             return _wrapper
-
-        return noodles.schedule(_add_logging(func))
+        func = _add_logging(func)
+        func._fairstep = fairstep
+        return noodles.schedule(func)
 
     return _modify_function
 

--- a/fairworkflows/fairworkflow.py
+++ b/fairworkflows/fairworkflow.py
@@ -11,6 +11,7 @@ import nanopub
 import networkx as nx
 import noodles
 import rdflib
+from noodles.display import NCDisplay
 from noodles.interface import PromisedObject
 from rdflib import RDF, RDFS, DCTERMS
 from rdflib.tools.rdf2dot import rdf2dot
@@ -400,7 +401,8 @@ class FairWorkflow(RdfWrapper):
         logger.setLevel(logging.INFO)
         logger.handlers = [log_handler]
         self.noodles_promise = self._replace_input_arguments(self.noodles_promise, args, kwargs)
-        result = noodles.run_single(self.noodles_promise)
+        with NCDisplay() as display:
+            result = noodles.run_logging(self.noodles_promise, 1, display)
 
         # Generate the retrospective provenance as a (nano-) Publication object
         retroprov = self._generate_retrospective_prov_publication(log.getvalue())

--- a/fairworkflows/fairworkflow.py
+++ b/fairworkflows/fairworkflow.py
@@ -11,13 +11,13 @@ import nanopub
 import networkx as nx
 import noodles
 import rdflib
-from noodles.display import NCDisplay
 from noodles.interface import PromisedObject
 from rdflib import RDF, RDFS, DCTERMS
 from rdflib.tools.rdf2dot import rdf2dot
 from requests import HTTPError
 
 from fairworkflows import namespaces
+from fairworkflows.config import LOGGER
 from fairworkflows.fairstep import FairStep
 from fairworkflows.rdf_wrapper import RdfWrapper
 
@@ -397,12 +397,10 @@ class FairWorkflow(RdfWrapper):
         formatter = logging.Formatter('%(asctime)s - %(message)s')
         log_handler.setFormatter(formatter)
 
-        logger = logging.getLogger('noodles')
-        logger.setLevel(logging.INFO)
-        logger.handlers = [log_handler]
+        LOGGER.setLevel(logging.INFO)
+        LOGGER.handlers = [log_handler]
         self.noodles_promise = self._replace_input_arguments(self.noodles_promise, args, kwargs)
-        with NCDisplay() as display:
-            result = noodles.run_logging(self.noodles_promise, 1, display)
+        result = noodles.run_single(self.noodles_promise)
 
         # Generate the retrospective provenance as a (nano-) Publication object
         retroprov = self._generate_retrospective_prov_publication(log.getvalue())

--- a/tests/test_fairworkflow.py
+++ b/tests/test_fairworkflow.py
@@ -4,6 +4,7 @@ from unittest import mock
 
 import pytest
 import rdflib
+from nanopub.definitions import DUMMY_NANOPUB_URI
 from requests import HTTPError
 
 from conftest import skip_if_nanopub_server_unavailable, read_rdf_test_resource
@@ -350,7 +351,12 @@ class TestFairWorkflow:
 
         result, prov = fw.execute(1, 4, 3)
         assert result == -66
+
         assert isinstance(prov, Publication)
+
+        prov_log = str(list(prov.assertion.objects(rdflib.URIRef(f'{DUMMY_NANOPUB_URI}#retroprov'),
+                                                   rdflib.RDFS.label))[0])
+        assert 'Running step: add' in prov_log
 
     def test_workflow_complex_serialization(self):
         class OtherType:


### PR DESCRIPTION
Use logging to track retrospective provenance during execution.
Provenance RDF for `test_workflow_construction_and_execution` now includes:
```
:assertion {
    :retroprov a prov:Activity ;
        rdfs:label """2021-02-11 12:21:30,506 - Running step: add
2021-02-11 12:21:30,506 - Running step: sub
2021-02-11 12:21:30,506 - Running step: weird
2021-02-11 12:21:30,507 - Running step: mul
""" ;
        prov:wasDerivedFrom <http://www.example.org/unpublishedworkflow> .
}
```

NB: I tried to make noodles log this, or inject information into noodles by passing `display: 'message'` to the schedule decorator as hint. This was quite a painful ride, hampered by lots of bugs in noodles in combination with an incomplete documentation. So, I decided to just work around it :)